### PR TITLE
Introduce redirect after sleeping for a recent block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neardata-server"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
A redirect forces clients to reestablish a connection, which hopefully will get a cached value from Cloudflare 