### PR TITLE
Use last blocks queue for upcoming blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neardata-server"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/src/api.rs
+++ b/src/api.rs
@@ -249,10 +249,17 @@ pub mod v0 {
                         }
 
                         if block_height > last_block_height {
-                            tokio::time::sleep(Duration::from_millis(
-                                100 + 1000 * (block_height - last_block_height - 1),
-                            ))
-                            .await;
+                            // We'll wait for the last blocks queue.
+                            cache::wait_for_block(
+                                app_state.redis_client.clone(),
+                                chain_id,
+                                block_height,
+                                finality,
+                                Duration::from_millis(
+                                    1000 * (block_height - last_block_height + 1),
+                                ),
+                            )
+                            .await?;
                             continue;
                         }
 


### PR DESCRIPTION
- Use the new feature from the caching-server that awaits on the last block