### PR TITLE
feat(api): New API methods for partial data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ serde_json = "1"
 dotenv = "0.15.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-redis = { version = "0.25.3", features = ["tokio-comp", "tokio-native-tls-comp", "streams"] }
+redis = { version = "0.25.3", features = [
+    "tokio-comp",
+    "tokio-native-tls-comp",
+    "streams",
+] }
 itertools = "0.12.0"
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tracing-actix-web = "0.7.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neardata-server"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ Example:
 - Genesis block (testnet) https://testnet.neardata.xyz/v0/block/42376888
 - Regular block (testnet) https://testnet.neardata.xyz/v0/block/100000000
 
+#### `v0/block/:block_height/headers`
+
+Returns a smaller part from the response including only the `block` part of the JSON object.
+
+Example:
+
+- Genesis block (mainnet) https://mainnet.neardata.xyz/v0/block/9820210/headers
+- Regular block (mainnet) https://mainnet.neardata.xyz/v0/block/98765432/headers
+- Missing block (mainnet) https://mainnet.neardata.xyz/v0/block/115001861/headers
+- Genesis block (testnet) https://testnet.neardata.xyz/v0/block/42376888/headers
+- Regular block (testnet) https://testnet.neardata.xyz/v0/block/100000000/headers
+
+#### `v0/block/:block_height/chunk/:shard_id`
+
+Returns a smaller part from the response including only the `chunk` of the requested `shard_id` part of the JSON object.
+
+Example:
+
+- Genesis block (mainnet) https://mainnet.neardata.xyz/v0/block/9820210/chunk/0
+- Regular block (mainnet) https://mainnet.neardata.xyz/v0/block/98765432/chunk/0
+- Missing block (mainnet) https://mainnet.neardata.xyz/v0/block/115001861/chunk/0
+- Genesis block (testnet) https://testnet.neardata.xyz/v0/block/42376888/chunk/0
+- Regular block (testnet) https://testnet.neardata.xyz/v0/block/100000000/chunk/0
+
 #### `/v0/block_opt/:block_height`
 
 Returns the optimistic block by block height.

--- a/src/api.rs
+++ b/src/api.rs
@@ -159,204 +159,53 @@ pub mod v0 {
         get_block_inner(block_height, Finality::Final, app_state).await
     }
 
+    /// Retrieves a block based on the given block height and finality.
+    ///
+    /// This function checks if the block height is within valid limits and handles redirects
+    /// to archive URLs if necessary. It then attempts to retrieve the block from the cache
+    /// or archive, and returns the block data as an HTTP response.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_height` - The height of the block to retrieve.
+    /// * `finality` - The finality of the block to retrieve (e.g., Final, Optimistic).
+    /// * `app_state` - The application state containing configuration and cache information.
+    ///
+    /// # Returns
+    ///
+    /// An HTTP response containing the block data or an error message.
     async fn get_block_inner(
         block_height: BlockHeight,
         finality: Finality,
         app_state: web::Data<AppState>,
     ) -> Result<impl Responder, ServiceError> {
-        let chain_id = app_state.chain_id;
+        let chain_id = app_state.chain_id.clone();
 
-        if block_height > MAX_BLOCK_HEIGHT {
-            return Ok(HttpResponse::NotFound()
-                .append_header((
-                    header::CACHE_CONTROL,
-                    format!("public, max-age={}", 24 * 60 * 60),
-                ))
-                .json(json!({
-                    "error": "Block height is too high",
-                    "type": "BLOCK_HEIGHT_TOO_HIGH"
-                })));
-        }
-        if block_height < app_state.genesis_block_height {
-            return Ok(HttpResponse::NotFound()
-                .append_header((
-                    header::CACHE_CONTROL,
-                    format!("public, max-age={}", 24 * 60 * 60),
-                ))
-                .json(json!({
-                    "error": "Block height is before the genesis",
-                    "type": "BLOCK_HEIGHT_TOO_LOW"
-                })));
+        // Check if the block height is within valid limits
+        if let Some(response) = check_block_height_limits(block_height, &app_state) {
+            return Ok(response);
         }
 
-        if let Some(archive_config) = &app_state.archive_config {
-            if app_state.is_latest && block_height < archive_config.end_height {
-                return Ok(HttpResponse::Found()
-                    .append_header((
-                        header::CACHE_CONTROL,
-                        format!("public, max-age={}", 24 * 60 * 60),
-                    ))
-                    .append_header((
-                        header::LOCATION,
-                        format!("{}/v0/block/{}", archive_config.archive_url, block_height),
-                    ))
-                    .finish());
-            } else if !app_state.is_latest
-                && (block_height >= archive_config.end_height || finality == Finality::Optimistic)
-            {
-                return Ok(HttpResponse::Found()
-                    .append_header((
-                        header::CACHE_CONTROL,
-                        format!("public, max-age={}", 24 * 60 * 60),
-                    ))
-                    .append_header((
-                        header::LOCATION,
-                        format!(
-                            "{}/v0/block{}/{}",
-                            archive_config.fresh_url,
-                            finality_suffix(finality),
-                            block_height
-                        ),
-                    ))
-                    .finish());
-            }
+        // Handle redirects to archive URLs if necessary
+        if let Some(response) = check_archive_redirects(block_height, finality, &app_state) {
+            return Ok(response);
         }
 
         tracing::debug!(target: TARGET_API, "Retrieving {} block for block_height: {}", finality, block_height);
 
-        let mut block = loop {
-            match cache::get_block_and_last_block_height(
-                app_state.redis_client.clone(),
-                chain_id,
-                block_height,
-                finality,
-            )
-            .await?
-            {
-                (Some(block), _) => break block,
-                (_, None) => {
-                    return Err(ServiceError::CacheError(
-                        "The last block height is missing from the cache".to_string(),
-                    ));
-                }
-                (None, Some(last_block_height)) => {
-                    // Not cached
-                    if app_state.is_latest {
-                        if block_height > last_block_height + MAX_WAIT_BLOCKS {
-                            return Ok(HttpResponse::NotFound().json(json!({
-                                "error": "The block is too far in the future",
-                                "type": "BLOCK_DOES_NOT_EXIST"
-                            })));
-                        }
+        // Retrieve the block from the cache or archive
+        let block =
+            retrieve_block_from_cache_or_archive(block_height, finality, &app_state, chain_id)
+                .await?;
 
-                        if block_height > last_block_height {
-                            // We'll wait for the last blocks queue.
-                            cache::wait_for_block(
-                                app_state.redis_client.clone(),
-                                chain_id,
-                                block_height,
-                                finality,
-                                Duration::from_millis(
-                                    1000 * (block_height - last_block_height + 1),
-                                ),
-                            )
-                            .await?;
-                            continue;
-                        }
-
-                        if block_height > last_block_height.saturating_sub(EXPECTED_CACHED_BLOCKS) {
-                            return Err(ServiceError::CacheError(
-                                "The block is not cached".to_string(),
-                            ));
-                        }
-                    }
-
-                    if finality == Finality::Optimistic {
-                        // Redirect to the final block
-                        return Ok(HttpResponse::Found()
-                            .append_header((
-                                header::CACHE_CONTROL,
-                                format!("public, max-age={}", 24 * 60 * 60),
-                            ))
-                            .append_header((
-                                header::LOCATION,
-                                format!("/v0/block/{}", block_height),
-                            ))
-                            .finish());
-                    }
-                    // If the read-path is not set, it means the server doesn't use archive files.
-                    // We have to redirect to the latest server with files.
-                    if app_state.read_config.is_none() {
-                        return Ok(HttpResponse::Found()
-                            .append_header((
-                                header::CACHE_CONTROL,
-                                format!("public, max-age={}", 24 * 60 * 60),
-                            ))
-                            .append_header((
-                                header::LOCATION,
-                                format!(
-                                    "{}/v0/block/{}",
-                                    app_state
-                                        .archive_config
-                                        .as_ref()
-                                        .expect("Missing archive config without local files config")
-                                        .latest_url,
-                                    block_height
-                                ),
-                            ))
-                            .finish());
-                    }
-
-                    // Before reading blocks we'll check the last time the archive was accessed and
-                    // indicate we want to read it.
-                    let archive_fn = archive_filename(
-                        &app_state.read_config.as_ref().unwrap(),
-                        chain_id,
-                        block_height,
-                    );
-                    let should_read = cache::acquire_archive_read_attempt(
-                        app_state.redis_client.clone(),
-                        &archive_fn,
-                    )
-                    .await?;
-
-                    if !should_read {
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                        continue;
-                    }
-
-                    let blocks = read_blocks(
-                        &app_state.read_config.as_ref().unwrap(),
-                        chain_id,
-                        block_height,
-                    );
-                    let block = blocks
-                        .iter()
-                        .find_map(|(height, block)| {
-                            if *height == block_height {
-                                Some(block.as_ref().cloned().unwrap_or_default())
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap();
-                    set_multiple_blocks_async(
-                        app_state.redis_client.clone(),
-                        chain_id,
-                        finality,
-                        blocks,
-                    );
-                    break block;
-                }
-            };
+        // Determine the cache duration based on whether the block is empty
+        let cache_duration = if block.is_empty() {
+            Duration::from_secs(24 * 60 * 60)
+        } else {
+            DEFAULT_CACHE_DURATION
         };
 
-        let mut cache_duration = DEFAULT_CACHE_DURATION;
-        if block.is_empty() {
-            block = "null".to_string();
-            // Temporary avoid caching empty blocks for too long
-            cache_duration = Duration::from_secs(24 * 60 * 60);
-        }
+        // Return the block data as an HTTP response
         Ok(HttpResponse::Ok()
             .append_header((header::CONTENT_TYPE, "application/json; charset=utf-8"))
             .append_header((
@@ -364,5 +213,256 @@ pub mod v0 {
                 format!("public, max-age={}", cache_duration.as_secs()),
             ))
             .body(block))
+    }
+
+    /// Checks if the block height is within valid limits.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_height` - The height of the block to check.
+    /// * `app_state` - The application state containing configuration information.
+    ///
+    /// # Returns
+    ///
+    /// An optional HTTP response indicating an error if the block height is out of bounds.
+    fn check_block_height_limits(
+        block_height: BlockHeight,
+        app_state: &web::Data<AppState>,
+    ) -> Option<HttpResponse> {
+        if block_height > MAX_BLOCK_HEIGHT {
+            return Some(
+                HttpResponse::NotFound()
+                    .append_header((
+                        header::CACHE_CONTROL,
+                        format!("public, max-age={}", 24 * 60 * 60),
+                    ))
+                    .json(json!({
+                        "error": "Block height is too high",
+                        "type": "BLOCK_HEIGHT_TOO_HIGH"
+                    })),
+            );
+        }
+        if block_height < app_state.genesis_block_height {
+            return Some(
+                HttpResponse::NotFound()
+                    .append_header((
+                        header::CACHE_CONTROL,
+                        format!("public, max-age={}", 24 * 60 * 60),
+                    ))
+                    .json(json!({
+                        "error": "Block height is before the genesis",
+                        "type": "BLOCK_HEIGHT_TOO_LOW"
+                    })),
+            );
+        }
+        None
+    }
+
+    /// Handles redirects to archive URLs if necessary.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_height` - The height of the block to check.
+    /// * `finality` - The finality of the block to check.
+    /// * `app_state` - The application state containing configuration information.
+    ///
+    /// # Returns
+    ///
+    /// An optional HTTP response indicating a redirect to an archive URL.
+    fn check_archive_redirects(
+        block_height: BlockHeight,
+        finality: Finality,
+        app_state: &web::Data<AppState>,
+    ) -> Option<HttpResponse> {
+        if let Some(archive_config) = &app_state.archive_config {
+            if app_state.is_latest && block_height < archive_config.end_height {
+                return Some(
+                    HttpResponse::Found()
+                        .append_header((
+                            header::CACHE_CONTROL,
+                            format!("public, max-age={}", 24 * 60 * 60),
+                        ))
+                        .append_header((
+                            header::LOCATION,
+                            format!("{}/v0/block/{}", archive_config.archive_url, block_height),
+                        ))
+                        .finish(),
+                );
+            } else if !app_state.is_latest
+                && (block_height >= archive_config.end_height || finality == Finality::Optimistic)
+            {
+                return Some(
+                    HttpResponse::Found()
+                        .append_header((
+                            header::CACHE_CONTROL,
+                            format!("public, max-age={}", 24 * 60 * 60),
+                        ))
+                        .append_header((
+                            header::LOCATION,
+                            format!(
+                                "{}/v0/block{}/{}",
+                                archive_config.fresh_url,
+                                finality_suffix(finality),
+                                block_height
+                            ),
+                        ))
+                        .finish(),
+                );
+            }
+        }
+        None
+    }
+
+    /// Retrieves the block from the cache or archive.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_height` - The height of the block to retrieve.
+    /// * `finality` - The finality of the block to retrieve.
+    /// * `app_state` - The application state containing configuration and cache information.
+    /// * `chain_id` - The chain ID of the blockchain.
+    ///
+    /// # Returns
+    ///
+    /// The block data as a string or an error.
+    async fn retrieve_block_from_cache_or_archive(
+        block_height: BlockHeight,
+        finality: Finality,
+        app_state: &web::Data<AppState>,
+        chain_id: ChainId,
+    ) -> Result<String, ServiceError> {
+        loop {
+            match cache::get_block_and_last_block_height(
+                app_state.redis_client.clone(),
+                chain_id.clone(),
+                block_height,
+                finality,
+            )
+            .await?
+            {
+                (Some(block), _) => return Ok(block),
+                (_, None) => {
+                    return Err(ServiceError::CacheError(
+                        "The last block height is missing from the cache".to_string(),
+                    ));
+                }
+                (None, Some(last_block_height)) => {
+                    if let Some(block) = handle_not_cached_block(
+                        block_height,
+                        last_block_height,
+                        finality,
+                        &app_state,
+                        chain_id.clone(),
+                    )
+                    .await?
+                    {
+                        return Ok(block);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handles the case where the block is not cached.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_height` - The height of the block to retrieve.
+    /// * `last_block_height` - The height of the last block in the cache.
+    /// * `finality` - The finality of the block to retrieve.
+    /// * `app_state` - The application state containing configuration and cache information.
+    /// * `chain_id` - The chain ID of the blockchain.
+    ///
+    /// # Returns
+    ///
+    /// An optional block data as a string or an error.
+    async fn handle_not_cached_block(
+        block_height: BlockHeight,
+        last_block_height: BlockHeight,
+        finality: Finality,
+        app_state: &web::Data<AppState>,
+        chain_id: ChainId,
+    ) -> Result<Option<String>, ServiceError> {
+        if app_state.is_latest {
+            if block_height > last_block_height + MAX_WAIT_BLOCKS {
+                return Ok(Some(
+                    json!({
+                        "error": "The block is too far in the future",
+                        "type": "BLOCK_DOES_NOT_EXIST"
+                    })
+                    .to_string(),
+                ));
+            }
+
+            if block_height > last_block_height {
+                cache::wait_for_block(
+                    app_state.redis_client.clone(),
+                    chain_id,
+                    block_height,
+                    finality,
+                    Duration::from_millis(1000 * (block_height - last_block_height + 1)),
+                )
+                .await?;
+                return Ok(None);
+            }
+
+            if block_height > last_block_height.saturating_sub(EXPECTED_CACHED_BLOCKS) {
+                return Err(ServiceError::CacheError(
+                    "The block is not cached".to_string(),
+                ));
+            }
+        }
+
+        if finality == Finality::Optimistic {
+            return Ok(Some(
+                json!({
+                    "error": "The block is not cached",
+                    "type": "BLOCK_NOT_CACHED"
+                })
+                .to_string(),
+            ));
+        }
+
+        if app_state.read_config.is_none() {
+            return Ok(Some(
+                json!({
+                    "error": "The block is not cached and no read config is available",
+                    "type": "BLOCK_NOT_CACHED_NO_READ_CONFIG"
+                })
+                .to_string(),
+            ));
+        }
+
+        let archive_fn = archive_filename(
+            &app_state.read_config.as_ref().unwrap(),
+            chain_id,
+            block_height,
+        );
+        let should_read =
+            cache::acquire_archive_read_attempt(app_state.redis_client.clone(), &archive_fn)
+                .await?;
+
+        if !should_read {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            return Ok(None);
+        }
+
+        let blocks = read_blocks(
+            &app_state.read_config.as_ref().unwrap(),
+            chain_id,
+            block_height,
+        );
+        let block = blocks
+            .iter()
+            .find_map(|(height, block)| {
+                if *height == block_height {
+                    Some(block.as_ref().cloned().unwrap_or_default())
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        set_multiple_blocks_async(app_state.redis_client.clone(), chain_id, finality, blocks);
+        Ok(Some(block))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cache;
 mod reader;
 mod types;
 
+use actix_web::web::service;
 use dotenv::dotenv;
 use std::env;
 
@@ -120,7 +121,9 @@ async fn main() -> std::io::Result<()> {
             .service(api::v0::get_first_block)
             .service(api::v0::get_block)
             .service(api::v0::get_opt_block)
-            .service(api::v0::get_last_block);
+            .service(api::v0::get_last_block)
+            .service(api::v0::get_block_headers)
+            .service(api::v0::get_chunk);
         App::new()
             .app_data(web::Data::new(AppState {
                 redis_client: redis_client.clone(),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -45,6 +45,7 @@ pub fn read_blocks(
 
 fn read_archive(path: &str) -> HashMap<String, String> {
     if !std::path::Path::new(path).exists() {
+        tracing::error!(target: TARGET, "File not found: {}", path);
         return HashMap::new();
     }
     tar::Archive::new(GzDecoder::new(std::fs::File::open(path).unwrap()))

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang='en'>
+
 <head>
   <meta charset='UTF-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1.0'>
@@ -45,164 +46,179 @@
       display: none;
     }
 
-    .toggle-bar input[type="radio"]:checked + label {
+    .toggle-bar input[type="radio"]:checked+label {
       background: rgba(33, 160, 44, 0.2);
       color: #000;
     }
   </style>
 </head>
+
 <body>
-<h1>NEAR Data Server by FASTNEAR</h1>
-<p>For more information, visit <a href='https://github.com/fastnear/neardata-server/'>GitHub</a></p>
+  <h1>NEAR Data Server by FASTNEAR</h1>
+  <p>For more information, visit <a href='https://github.com/fastnear/neardata-server/'>GitHub</a></p>
 
-<h2>LIVE LATENCY TEST</h2>
-<div id="latency">
-  <div class="toggle-bar">
-    Block type:
-    <input type="radio" id="final" name="blocktype" value="final" checked>
-    <label class="left" for="final">Final</label>
-    <input type="radio" id="optimistic" name="blocktype" value="optimistic">
-    <label class="right" for="optimistic">Optimistic</label>
-  </div>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js"></script>
-  <canvas id="chart"></canvas>
-  <script>
-    let blockType = "final";
-    let selectBlockType;
+  <h2>LIVE LATENCY TEST</h2>
+  <div id="latency">
+    <div class="toggle-bar">
+      Block type:
+      <input type="radio" id="final" name="blocktype" value="final" checked>
+      <label class="left" for="final">Final</label>
+      <input type="radio" id="optimistic" name="blocktype" value="optimistic">
+      <label class="right" for="optimistic">Optimistic</label>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js"></script>
+    <canvas id="chart"></canvas>
+    <script>
+      let blockType = "final";
+      let selectBlockType;
 
-    // Listen to radio above changing:
-    document.querySelector('.toggle-bar').addEventListener('change', (event) => {
-      if (event.target.type === 'radio' && event.target.checked) {
-        console.log(`Selected block type: ${event.target.value}`);
-        selectBlockType(event.target.value);
-      }
-    });
-
-    const ctx = document.getElementById('chart').getContext('2d');
-    const MaxLength = 30;
-    const rootUrl = "";
-    const chart = new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels: [],
-        datasets: [{
-          label: 'Pending',
-          data: [],
-          backgroundColor: 'rgba(33, 160, 44, 0.2)',
-          borderColor: 'rgba(33, 160, 44, 1)',
-          borderWidth: 2
-        }]
-      },
-      options: {
-        scales: {
-          y: {
-            beginAtZero: true,
-            title: {
-              display: true,
-              text: 'Latency (seconds)'
-            }
-          },
-          x: {
-            title: {
-              display: true,
-              text: 'Block Height'
-            }
-          }
+      // Listen to radio above changing:
+      document.querySelector('.toggle-bar').addEventListener('change', (event) => {
+        if (event.target.type === 'radio' && event.target.checked) {
+          console.log(`Selected block type: ${event.target.value}`);
+          selectBlockType(event.target.value);
         }
-      }
-    });
-    let nonce = 0;
-
-    const fetchUntilSuccess = async (url, currentNonce) => {
-      while (nonce === currentNonce) {
-        try {
-          console.log("Fetching ", url);
-          return await (await fetch(url)).json();
-        } catch (e) {
-          console.error("Failed to fetch url", url, ": ", e);
-          // Sleep 500
-          await new Promise((resolve) => setTimeout(resolve, 500));
-        }
-      }
-    }
-    // Initial block
-    const fetcher = async (blockType, currentNonce) => {
-      const initialBlock = await fetchUntilSuccess(rootUrl + `/v0/last_block/${blockType}`, currentNonce);
-      const startBlockHeight = initialBlock.block.header.height;
-      // Only stream for 300 blocks ~ 5 minute
-      for (let i = 1; nonce === currentNonce && i <= 300; ++i) {
-        const blockHeight = startBlockHeight + i;
-        const block = await fetchUntilSuccess(rootUrl + `/v0/${blockType === "final" ? "block" : "block_opt"}/${blockHeight}`, currentNonce);
-        if (nonce === currentNonce && block) {
-          const blockTime = parseFloat(block.block.header.timestamp_nanosec) / 1e9;
-          const time = new Date().getTime() / 1e3;
-          const latency = time - blockTime;
-          chart.data.labels.push(blockHeight);
-          chart.data.datasets[0].data.push(latency);
-          if (chart.data.labels.length > MaxLength) {
-            chart.data.labels.shift();
-            chart.data.datasets[0].data.shift();
-          }
-          chart.update();
-        }
-      }
-    };
-
-    selectBlockType = (newBlockType) => {
-      nonce++;
-      blockType = newBlockType;
-      chart.data.labels = [];
-      chart.data.datasets[0].data = [];
-      chart.data.datasets[0].label = `${blockType.slice(0, 1).toUpperCase() + blockType.slice(1)} blocks latency`;
-      chart.update();
-      fetcher(blockType, nonce).then(() => {
       });
-    }
 
-    selectBlockType(blockType);
+      const ctx = document.getElementById('chart').getContext('2d');
+      const MaxLength = 30;
+      const rootUrl = "";
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: [],
+          datasets: [{
+            label: 'Pending',
+            data: [],
+            backgroundColor: 'rgba(33, 160, 44, 0.2)',
+            borderColor: 'rgba(33, 160, 44, 1)',
+            borderWidth: 2
+          }]
+        },
+        options: {
+          scales: {
+            y: {
+              beginAtZero: true,
+              title: {
+                display: true,
+                text: 'Latency (seconds)'
+              }
+            },
+            x: {
+              title: {
+                display: true,
+                text: 'Block Height'
+              }
+            }
+          }
+        }
+      });
+      let nonce = 0;
 
-  </script>
-</div>
+      const fetchUntilSuccess = async (url, currentNonce) => {
+        while (nonce === currentNonce) {
+          try {
+            console.log("Fetching ", url);
+            return await (await fetch(url)).json();
+          } catch (e) {
+            console.error("Failed to fetch url", url, ": ", e);
+            // Sleep 500
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+        }
+      }
+      // Initial block
+      const fetcher = async (blockType, currentNonce) => {
+        const initialBlock = await fetchUntilSuccess(rootUrl + `/v0/last_block/${blockType}`, currentNonce);
+        const startBlockHeight = initialBlock.block.header.height;
+        // Only stream for 300 blocks ~ 5 minute
+        for (let i = 1; nonce === currentNonce && i <= 300; ++i) {
+          const blockHeight = startBlockHeight + i;
+          const block = await fetchUntilSuccess(rootUrl + `/v0/${blockType === "final" ? "block" : "block_opt"}/${blockHeight}`, currentNonce);
+          if (nonce === currentNonce && block) {
+            const blockTime = parseFloat(block.block.header.timestamp_nanosec) / 1e9;
+            const time = new Date().getTime() / 1e3;
+            const latency = time - blockTime;
+            chart.data.labels.push(blockHeight);
+            chart.data.datasets[0].data.push(latency);
+            if (chart.data.labels.length > MaxLength) {
+              chart.data.labels.shift();
+              chart.data.datasets[0].data.shift();
+            }
+            chart.update();
+          }
+        }
+      };
 
-<h2>API</h2>
-<h3>GET /v0/block</h3>
+      selectBlockType = (newBlockType) => {
+        nonce++;
+        blockType = newBlockType;
+        chart.data.labels = [];
+        chart.data.datasets[0].data = [];
+        chart.data.datasets[0].label = `${blockType.slice(0, 1).toUpperCase() + blockType.slice(1)} blocks latency`;
+        chart.update();
+        fetcher(blockType, nonce).then(() => {
+        });
+      }
 
-<p>Returns the finalized block by block height.</p>
-<ul>
-  <li> If the block doesn't exist it returns <code>null</code>.</li>
-  <li> If the block is not produced yet, but close to the current finalized block,
-    the server will wait for the block to be produced and return it.
-  </li>
-  <li> The difference from NEAR Lake data is each block is served as a single
-    JSON object, instead of the block and shards. Another benefit, is we include
-    the <code>tx_hash</code> for every receipt in the <code>receipt_execution_outcomes</code>.
-    The <code>tx_hash</code> is the hash of the transaction that produced the receipt.
-  </li>
-</ul>
+      selectBlockType(blockType);
 
-<p>Example: <a href='/v0/block/100000000'>/v0/block/100000000</a></p>
+    </script>
+  </div>
 
-<h3>GET /v0/block_opt</h3>
-<p>Returns the optimistic block by block height or redirects to the finalized block.</p>
+  <h2>API</h2>
+  <h3>GET /v0/block</h3>
 
-<p>Example: <a href='/v0/block_opt/122000000'>/v0/block_opt/122000000</a></p>
+  <p>Returns the finalized block by block height.</p>
+  <ul>
+    <li> If the block doesn't exist it returns <code>null</code>.</li>
+    <li> If the block is not produced yet, but close to the current finalized block,
+      the server will wait for the block to be produced and return it.
+    </li>
+    <li> The difference from NEAR Lake data is each block is served as a single
+      JSON object, instead of the block and shards. Another benefit, is we include
+      the <code>tx_hash</code> for every receipt in the <code>receipt_execution_outcomes</code>.
+      The <code>tx_hash</code> is the hash of the transaction that produced the receipt.
+    </li>
+  </ul>
 
-<h3>GET /v0/first_block</h3>
-<p>Redirects to the first block after genesis.</p>
-<p>The block is guaranteed to exist and will be returned immediately.</p>
+  <p>Example: <a href='/v0/block/100000000'>/v0/block/100000000</a></p>
 
-<p>Example: <a href='/v0/first_block'>/v0/first_block</a></p>
+  <h3>GET /v0/block/:block_height/headers</h3>
 
-<h3>GET /v0/last_block/final</h3>
-<p>Redirects to the latest finalized block.</p>
-<p>The block is guaranteed to exist and will be returned immediately.</p>
+  <p>Logic is similar to the <code>GET /v0/block/</code> but returns only the <code>.block</code> key from the big
+    response. This will include the block header with chunk headers</p>
 
-<p>Example: <a href='/v0/last_block/final'>/v0/last_block/final</a></p>
+  <p>Example: <a href='/v0/block/100000000/headers'>/v0/block/100000000/headers</a></p>
 
-<h3>GET /v0/last_block/optimistic</h3>
-<p>Redirects to the latest optimistic block.</p>
-<p>The block is guaranteed to exist and will be returned immediately.</p>
+  <h3>GET /v0/block/:block_height/chunks/:shard_id</h3>
 
-<p>Example: <a href='/v0/last_block/optimistic'>/v0/last_block/optimistic</a></p>
+  <p>Returns a single chunk of the block <code>:block_height</code> of the shard <code>:shard_id</code></p>
+
+  <p>Example: <a href='/v0/block/100000000/chunks/0'>/v0/block/100000000/chunks/0</a></p>
+
+  <h3>GET /v0/block_opt</h3>
+  <p>Returns the optimistic block by block height or redirects to the finalized block.</p>
+
+  <p>Example: <a href='/v0/block_opt/122000000'>/v0/block_opt/122000000</a></p>
+
+  <h3>GET /v0/first_block</h3>
+  <p>Redirects to the first block after genesis.</p>
+  <p>The block is guaranteed to exist and will be returned immediately.</p>
+
+  <p>Example: <a href='/v0/first_block'>/v0/first_block</a></p>
+
+  <h3>GET /v0/last_block/final</h3>
+  <p>Redirects to the latest finalized block.</p>
+  <p>The block is guaranteed to exist and will be returned immediately.</p>
+
+  <p>Example: <a href='/v0/last_block/final'>/v0/last_block/final</a></p>
+
+  <h3>GET /v0/last_block/optimistic</h3>
+  <p>Redirects to the latest optimistic block.</p>
+  <p>The block is guaranteed to exist and will be returned immediately.</p>
+
+  <p>Example: <a href='/v0/last_block/optimistic'>/v0/last_block/optimistic</a></p>
 </body>
+
 </html>


### PR DESCRIPTION
This PR contains two commits, one is a big refactoring of the `src/api.rs::get_block_inner` function to split into smaller pieces and add docstrings to improve readability.

And the second one introduces two additional API methods:

`v0/block/:block_height/headers` - returns only `block` part of the big JSON
`v0/block/:block_height/chunk/:shard_id` - returns only `chunk` from the requested `:shard_id`

The README is updated with new methods.