### PR TITLE
0.8.1: Fix redirects. Update error codes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neardata-server"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ Example:
 - Genesis block (testnet) https://testnet.neardata.xyz/v0/block/42376888/chunk/0
 - Regular block (testnet) https://testnet.neardata.xyz/v0/block/100000000/chunk/0
 
+#### `v0/block/:block_height/shard/:shard_id`
+
+Returns a smaller part from the response including only the `shard` of the requested `shard_id` part of the JSON object.
+
+Example:
+
+- Genesis block (mainnet) https://mainnet.neardata.xyz/v0/block/9820210/shard/0
+- Regular block (mainnet) https://mainnet.neardata.xyz/v0/block/98765432/shard/0
+- Missing block (mainnet) https://mainnet.neardata.xyz/v0/block/115001861/shard/0
+- Genesis block (testnet) https://testnet.neardata.xyz/v0/block/42376888/shard/0
+- Regular block (testnet) https://testnet.neardata.xyz/v0/block/100000000/shard/0
+
 #### `/v0/block_opt/:block_height`
 
 Returns the optimistic block by block height.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ mod cache;
 mod reader;
 mod types;
 
-use actix_web::web::service;
 use dotenv::dotenv;
 use std::env;
 
@@ -120,9 +119,9 @@ async fn main() -> std::io::Result<()> {
         let api_v0 = web::scope("/v0")
             .service(api::v0::get_first_block)
             .service(api::v0::get_block)
-            .service(api::v0::get_opt_block)
             .service(api::v0::get_last_block)
             .service(api::v0::get_block_headers)
+            .service(api::v0::get_shard)
             .service(api::v0::get_chunk);
         App::new()
             .app_data(web::Data::new(AppState {

--- a/static/index.html
+++ b/static/index.html
@@ -46,7 +46,7 @@
       display: none;
     }
 
-    .toggle-bar input[type="radio"]:checked+label {
+    .toggle-bar input[type="radio"]:checked + label {
       background: rgba(33, 160, 44, 0.2);
       color: #000;
     }
@@ -54,171 +54,177 @@
 </head>
 
 <body>
-  <h1>NEAR Data Server by FASTNEAR</h1>
-  <p>For more information, visit <a href='https://github.com/fastnear/neardata-server/'>GitHub</a></p>
+<h1>NEAR Data Server by FASTNEAR</h1>
+<p>For more information, visit <a href='https://github.com/fastnear/neardata-server/'>GitHub</a></p>
 
-  <h2>LIVE LATENCY TEST</h2>
-  <div id="latency">
-    <div class="toggle-bar">
-      Block type:
-      <input type="radio" id="final" name="blocktype" value="final" checked>
-      <label class="left" for="final">Final</label>
-      <input type="radio" id="optimistic" name="blocktype" value="optimistic">
-      <label class="right" for="optimistic">Optimistic</label>
-    </div>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js"></script>
-    <canvas id="chart"></canvas>
-    <script>
-      let blockType = "final";
-      let selectBlockType;
-
-      // Listen to radio above changing:
-      document.querySelector('.toggle-bar').addEventListener('change', (event) => {
-        if (event.target.type === 'radio' && event.target.checked) {
-          console.log(`Selected block type: ${event.target.value}`);
-          selectBlockType(event.target.value);
-        }
-      });
-
-      const ctx = document.getElementById('chart').getContext('2d');
-      const MaxLength = 30;
-      const rootUrl = "";
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: [],
-          datasets: [{
-            label: 'Pending',
-            data: [],
-            backgroundColor: 'rgba(33, 160, 44, 0.2)',
-            borderColor: 'rgba(33, 160, 44, 1)',
-            borderWidth: 2
-          }]
-        },
-        options: {
-          scales: {
-            y: {
-              beginAtZero: true,
-              title: {
-                display: true,
-                text: 'Latency (seconds)'
-              }
-            },
-            x: {
-              title: {
-                display: true,
-                text: 'Block Height'
-              }
-            }
-          }
-        }
-      });
-      let nonce = 0;
-
-      const fetchUntilSuccess = async (url, currentNonce) => {
-        while (nonce === currentNonce) {
-          try {
-            console.log("Fetching ", url);
-            return await (await fetch(url)).json();
-          } catch (e) {
-            console.error("Failed to fetch url", url, ": ", e);
-            // Sleep 500
-            await new Promise((resolve) => setTimeout(resolve, 500));
-          }
-        }
-      }
-      // Initial block
-      const fetcher = async (blockType, currentNonce) => {
-        const initialBlock = await fetchUntilSuccess(rootUrl + `/v0/last_block/${blockType}`, currentNonce);
-        const startBlockHeight = initialBlock.block.header.height;
-        // Only stream for 300 blocks ~ 5 minute
-        for (let i = 1; nonce === currentNonce && i <= 300; ++i) {
-          const blockHeight = startBlockHeight + i;
-          const block = await fetchUntilSuccess(rootUrl + `/v0/${blockType === "final" ? "block" : "block_opt"}/${blockHeight}`, currentNonce);
-          if (nonce === currentNonce && block) {
-            const blockTime = parseFloat(block.block.header.timestamp_nanosec) / 1e9;
-            const time = new Date().getTime() / 1e3;
-            const latency = time - blockTime;
-            chart.data.labels.push(blockHeight);
-            chart.data.datasets[0].data.push(latency);
-            if (chart.data.labels.length > MaxLength) {
-              chart.data.labels.shift();
-              chart.data.datasets[0].data.shift();
-            }
-            chart.update();
-          }
-        }
-      };
-
-      selectBlockType = (newBlockType) => {
-        nonce++;
-        blockType = newBlockType;
-        chart.data.labels = [];
-        chart.data.datasets[0].data = [];
-        chart.data.datasets[0].label = `${blockType.slice(0, 1).toUpperCase() + blockType.slice(1)} blocks latency`;
-        chart.update();
-        fetcher(blockType, nonce).then(() => {
-        });
-      }
-
-      selectBlockType(blockType);
-
-    </script>
+<h2>LIVE LATENCY TEST</h2>
+<div id="latency">
+  <div class="toggle-bar">
+    Block type:
+    <input type="radio" id="final" name="blocktype" value="final" checked>
+    <label class="left" for="final">Final</label>
+    <input type="radio" id="optimistic" name="blocktype" value="optimistic">
+    <label class="right" for="optimistic">Optimistic</label>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js"></script>
+  <canvas id="chart"></canvas>
+  <script>
+    let blockType = "final";
+    let selectBlockType;
 
-  <h2>API</h2>
-  <h3>GET /v0/block</h3>
+    // Listen to radio above changing:
+    document.querySelector('.toggle-bar').addEventListener('change', (event) => {
+      if (event.target.type === 'radio' && event.target.checked) {
+        console.log(`Selected block type: ${event.target.value}`);
+        selectBlockType(event.target.value);
+      }
+    });
 
-  <p>Returns the finalized block by block height.</p>
-  <ul>
-    <li> If the block doesn't exist it returns <code>null</code>.</li>
-    <li> If the block is not produced yet, but close to the current finalized block,
-      the server will wait for the block to be produced and return it.
-    </li>
-    <li> The difference from NEAR Lake data is each block is served as a single
-      JSON object, instead of the block and shards. Another benefit, is we include
-      the <code>tx_hash</code> for every receipt in the <code>receipt_execution_outcomes</code>.
-      The <code>tx_hash</code> is the hash of the transaction that produced the receipt.
-    </li>
-  </ul>
+    const ctx = document.getElementById('chart').getContext('2d');
+    const MaxLength = 30;
+    const rootUrl = "";
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [{
+          label: 'Pending',
+          data: [],
+          backgroundColor: 'rgba(33, 160, 44, 0.2)',
+          borderColor: 'rgba(33, 160, 44, 1)',
+          borderWidth: 2
+        }]
+      },
+      options: {
+        scales: {
+          y: {
+            beginAtZero: true,
+            title: {
+              display: true,
+              text: 'Latency (seconds)'
+            }
+          },
+          x: {
+            title: {
+              display: true,
+              text: 'Block Height'
+            }
+          }
+        }
+      }
+    });
+    let nonce = 0;
 
-  <p>Example: <a href='/v0/block/100000000'>/v0/block/100000000</a></p>
+    const fetchUntilSuccess = async (url, currentNonce) => {
+      while (nonce === currentNonce) {
+        try {
+          console.log("Fetching ", url);
+          return await (await fetch(url)).json();
+        } catch (e) {
+          console.error("Failed to fetch url", url, ": ", e);
+          // Sleep 500
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+      }
+    }
+    // Initial block
+    const fetcher = async (blockType, currentNonce) => {
+      const initialBlock = await fetchUntilSuccess(rootUrl + `/v0/last_block/${blockType}`, currentNonce);
+      const startBlockHeight = initialBlock.block.header.height;
+      // Only stream for 300 blocks ~ 5 minute
+      for (let i = 1; nonce === currentNonce && i <= 300; ++i) {
+        const blockHeight = startBlockHeight + i;
+        const block = await fetchUntilSuccess(rootUrl + `/v0/${blockType === "final" ? "block" : "block_opt"}/${blockHeight}`, currentNonce);
+        if (nonce === currentNonce && block) {
+          const blockTime = parseFloat(block.block.header.timestamp_nanosec) / 1e9;
+          const time = new Date().getTime() / 1e3;
+          const latency = time - blockTime;
+          chart.data.labels.push(blockHeight);
+          chart.data.datasets[0].data.push(latency);
+          if (chart.data.labels.length > MaxLength) {
+            chart.data.labels.shift();
+            chart.data.datasets[0].data.shift();
+          }
+          chart.update();
+        }
+      }
+    };
 
-  <h3>GET /v0/block/:block_height/headers</h3>
+    selectBlockType = (newBlockType) => {
+      nonce++;
+      blockType = newBlockType;
+      chart.data.labels = [];
+      chart.data.datasets[0].data = [];
+      chart.data.datasets[0].label = `${blockType.slice(0, 1).toUpperCase() + blockType.slice(1)} blocks latency`;
+      chart.update();
+      fetcher(blockType, nonce).then(() => {
+      });
+    }
 
-  <p>Logic is similar to the <code>GET /v0/block/</code> but returns only the <code>.block</code> key from the big
-    response. This will include the block header with chunk headers</p>
+    selectBlockType(blockType);
 
-  <p>Example: <a href='/v0/block/100000000/headers'>/v0/block/100000000/headers</a></p>
+  </script>
+</div>
 
-  <h3>GET /v0/block/:block_height/chunks/:shard_id</h3>
+<h2>API</h2>
+<h3>GET /v0/block</h3>
 
-  <p>Returns a single chunk of the block <code>:block_height</code> of the shard <code>:shard_id</code></p>
+<p>Returns the finalized block by block height.</p>
+<ul>
+  <li> If the block doesn't exist it returns <code>null</code>.</li>
+  <li> If the block is not produced yet, but close to the current finalized block,
+    the server will wait for the block to be produced and return it.
+  </li>
+  <li> The difference from NEAR Lake data is each block is served as a single
+    JSON object, instead of the block and shards. Another benefit, is we include
+    the <code>tx_hash</code> for every receipt in the <code>receipt_execution_outcomes</code>.
+    The <code>tx_hash</code> is the hash of the transaction that produced the receipt.
+  </li>
+</ul>
 
-  <p>Example: <a href='/v0/block/100000000/chunks/0'>/v0/block/100000000/chunks/0</a></p>
+<p>Example: <a href='/v0/block/100000000'>/v0/block/100000000</a></p>
 
-  <h3>GET /v0/block_opt</h3>
-  <p>Returns the optimistic block by block height or redirects to the finalized block.</p>
+<h3>GET /v0/block/:block_height/headers</h3>
 
-  <p>Example: <a href='/v0/block_opt/122000000'>/v0/block_opt/122000000</a></p>
+<p>Logic is similar to the <code>GET /v0/block/</code> but returns only the <code>.block</code> key from the big
+  response. This will include the block header with chunk headers</p>
 
-  <h3>GET /v0/first_block</h3>
-  <p>Redirects to the first block after genesis.</p>
-  <p>The block is guaranteed to exist and will be returned immediately.</p>
+<p>Example: <a href='/v0/block/100000000/headers'>/v0/block/100000000/headers</a></p>
 
-  <p>Example: <a href='/v0/first_block'>/v0/first_block</a></p>
+<h3>GET /v0/block/:block_height/chunk/:shard_id</h3>
 
-  <h3>GET /v0/last_block/final</h3>
-  <p>Redirects to the latest finalized block.</p>
-  <p>The block is guaranteed to exist and will be returned immediately.</p>
+<p>Returns a single chunk of the block <code>:block_height</code> of the shard <code>:shard_id</code></p>
 
-  <p>Example: <a href='/v0/last_block/final'>/v0/last_block/final</a></p>
+<p>Example: <a href='/v0/block/100000000/chunk/0'>/v0/block/100000000/chunk/0</a></p>
 
-  <h3>GET /v0/last_block/optimistic</h3>
-  <p>Redirects to the latest optimistic block.</p>
-  <p>The block is guaranteed to exist and will be returned immediately.</p>
+<h3>GET /v0/block/:block_height/shard/:shard_id</h3>
 
-  <p>Example: <a href='/v0/last_block/optimistic'>/v0/last_block/optimistic</a></p>
+<p>Returns a single shard of the block <code>:block_height</code> of the shard <code>:shard_id</code></p>
+
+<p>Example: <a href='/v0/block/100000000/shard/0'>/v0/block/100000000/shard/0</a></p>
+
+<h3>GET /v0/block_opt</h3>
+<p>Returns the optimistic block by block height or redirects to the finalized block.</p>
+
+<p>Example: <a href='/v0/block_opt/122000000'>/v0/block_opt/122000000</a></p>
+
+<h3>GET /v0/first_block</h3>
+<p>Redirects to the first block after genesis.</p>
+<p>The block is guaranteed to exist and will be returned immediately.</p>
+
+<p>Example: <a href='/v0/first_block'>/v0/first_block</a></p>
+
+<h3>GET /v0/last_block/final</h3>
+<p>Redirects to the latest finalized block.</p>
+<p>The block is guaranteed to exist and will be returned immediately.</p>
+
+<p>Example: <a href='/v0/last_block/final'>/v0/last_block/final</a></p>
+
+<h3>GET /v0/last_block/optimistic</h3>
+<p>Redirects to the latest optimistic block.</p>
+<p>The block is guaranteed to exist and will be returned immediately.</p>
+
+<p>Example: <a href='/v0/last_block/optimistic'>/v0/last_block/optimistic</a></p>
 </body>
 
 </html>


### PR DESCRIPTION
- Handle skipped blocks
- Fix redirect issue when blocks are on archive machines
- Introduce `shard/0` as an option to retrieve `shard` object instead of inner `chunk`
- Support `block_opt` for headers, chunks and shards 
- Refactor more