### PR TITLE
Handle Fresh node redirects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neardata-server"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
- redirect when optimistic block is our of cache
- redirect when fresh data node (no storage) is out cache