### PR TITLE
Rework archive redirects to support more than one archive node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,7 @@ redis = { version = "0.25.3", features = [
 ] }
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tracing-actix-web = "0.7.9"
-
-
 reqwest = { version = "0.11.24", features = ["json"] }
-
 openssl-probe = "0.1.5"
-
 tar = "0.4"
 flate2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neardata-server"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]
@@ -16,16 +16,12 @@ redis = { version = "0.25.3", features = [
     "tokio-native-tls-comp",
     "streams",
 ] }
-itertools = "0.12.0"
 tokio = { version = "1.36.0", features = ["full", "tracing"] }
 tracing-actix-web = "0.7.9"
 
-near-account-id = "0.1.0"
-near-crypto = "0.20.0"
 
 reqwest = { version = "0.11.24", features = ["json"] }
-base64 = "0.21.7"
-hex = "0.4.3"
+
 openssl-probe = "0.1.5"
 
 tar = "0.4"

--- a/static/index.html
+++ b/static/index.html
@@ -129,14 +129,14 @@
     }
     // Initial block
     const fetcher = async (blockType, currentNonce) => {
-      const initialBlock = await fetchUntilSuccess(rootUrl + `/v0/last_block/${blockType}`, currentNonce);
-      const startBlockHeight = initialBlock.block.header.height;
+      const initialHeaders = await fetchUntilSuccess(rootUrl + `/v0/last_block/${blockType}/headers`, currentNonce);
+      const startBlockHeight = initialHeaders.header.height;
       // Only stream for 300 blocks ~ 5 minute
       for (let i = 1; nonce === currentNonce && i <= 300; ++i) {
         const blockHeight = startBlockHeight + i;
-        const block = await fetchUntilSuccess(rootUrl + `/v0/${blockType === "final" ? "block" : "block_opt"}/${blockHeight}`, currentNonce);
-        if (nonce === currentNonce && block) {
-          const blockTime = parseFloat(block.block.header.timestamp_nanosec) / 1e9;
+        const headers = await fetchUntilSuccess(rootUrl + `/v0/${blockType === "final" ? "block" : "block_opt"}/${blockHeight}/headers`, currentNonce);
+        if (nonce === currentNonce && headers) {
+          const blockTime = parseFloat(headers.header.timestamp_nanosec) / 1e9;
           const time = new Date().getTime() / 1e3;
           const latency = time - blockTime;
           chart.data.labels.push(blockHeight);


### PR DESCRIPTION
New `.env` config for archive nodes, e.g.:
```
IS_LATEST=true
IS_FRESH=true
ARCHIVE_INDEX=1
DOMAIN_NAME=mainnet.neardata.xyz
ARCHIVE_BOUNDARIES=122000000,141100000
```

Support `/v0/last_block/final/headers` for smaller overhead.