### PR TITLE
add openapi generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,15 @@ name = "neardata-server"
 version = "0.10.2"
 edition = "2021"
 
+[features]
+default = []
+openapi = ["dep:fastnear-openapi-generator", "dep:schemars"]
+
+[[bin]]
+name = "generate-openapi"
+path = "src/bin/generate-openapi.rs"
+required-features = ["openapi"]
+
 [dependencies]
 actix-web = "4.5.1"
 actix-cors = "0.7.0"
@@ -22,3 +31,6 @@ reqwest = { version = "0.11.24", features = ["json"] }
 openssl-probe = "0.1.5"
 tar = "0.4"
 flate2 = "1.0"
+anyhow = "1"
+fastnear-openapi-generator = { version = "0.2.0", optional = true }
+schemars = { version = "1.2.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ FASTNEAR provides servers for both mainnet and testnet:
 - Mainnet: [https://mainnet.neardata.xyz](https://mainnet.neardata.xyz)
 - Testnet: [https://testnet.neardata.xyz](https://testnet.neardata.xyz)
 
+## OpenAPI Generation
+
+The checked-in `openapi/openapi.yaml` file is generated from small typed DTOs plus a Rust-owned operation registry.
+
+```bash
+cargo run --features openapi --bin generate-openapi
+cargo run --features openapi --bin generate-openapi -- --check
+```
+
+The docs pipeline is:
+
+`neardata-server` generator -> checked-in `openapi/openapi.yaml` -> `mike-docs` split + sync -> `builder-docs` direct docs runtime
+
 ## API
 
 The server provides the following endpoints:
@@ -42,7 +55,7 @@ To increase your rate limits, get a subscription at [https://fastnear.com/](http
 
 ### Authentication
 
-To authenticate your requests with a FastNear Subscription API key, attach the following query string to the URL:
+To authenticate your requests with a FastNEAR Subscription API key, attach the following query string to the URL:
 
 ```
 ?apiKey={API_KEY}
@@ -52,6 +65,8 @@ For example:
 ```
 https://mainnet.neardata.xyz/v0/block/98765432?apiKey=YOUR_API_KEY
 ```
+
+Invalid API keys may return `401 Unauthorized` before the request reaches the neardata application itself.
 
 > **Note:** Authentication using the `Authorization: Bearer` header requires you to manually handle redirects, since the redirect URL will not pass the header through and the redirected request will not be authenticated.
 
@@ -79,6 +94,7 @@ Returns the block by block height.
 - If the block doesn't exist it returns `null`.
 - If the block is not produced yet, but close to the current finalized block, the server will wait for the block to be
   produced and return it.
+- Depending on deployment topology, this route may redirect to the host that owns the canonical archive range for the requested block.
 - The difference from NEAR Lake data is each block is served as a single JSON object, instead of the block and shards.
   Another benefit, is we include the `tx_hash` for every receipt in the `receipt_execution_outcomes`. The `tx_hash` is
   the hash of the transaction that produced the receipt.
@@ -93,7 +109,7 @@ Example:
 
 #### `v0/block/:block_height/headers`
 
-Returns a smaller part from the response including only the `block` part of the JSON object.
+Returns a smaller part from the response including only the `block` object from the JSON document.
 
 Example:
 
@@ -131,7 +147,7 @@ Example:
 
 Returns the optimistic block by block height.
 
-If the block is relatively old it will be redirected to the finalized block.
+If the deployment cannot serve the requested optimistic block directly, it may redirect to a canonical finalized or archive URL.
 
 #### `/v0/last_block/final`
 
@@ -185,4 +201,3 @@ cargo run
 - `READ_PATH` - The path to the directory with the block files.
 - `SAVE_EVERY_N` - The number of blocks to save in the cache before saving to the disk.
 - `GENESIS_BLOCK_HEIGHT` - The block height of the genesis block.
-

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -33,7 +33,7 @@ openapi: 3.0.3
 paths:
   /health:
     get:
-      description: Check whether the neardata service is healthy for the current deployment.
+      description: 'Ping the neardata service for liveness — returns `{status: ok}` when healthy, errors otherwise.'
       operationId: get_health
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
@@ -71,7 +71,7 @@ paths:
       x-fastnear-title: NEAR Data API - Health
   /v0/block/{block_height}:
     get:
-      description: Fetch the finalized block document for a given height, including all chunks and shard data.
+      description: Fetch a finalized block's full document at a chosen height — header plus every chunk and shard payload.
       operationId: get_block
       parameters:
       - description: NEAR block height to retrieve.
@@ -132,7 +132,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block
   /v0/block/{block_height}/chunk/{shard_id}:
     get:
-      description: Fetch a single chunk for a given finalized block and shard ID.
+      description: Fetch one chunk — a single shard's transactions and incoming receipts — at a chosen block height.
       operationId: get_chunk
       parameters:
       - description: NEAR block height to retrieve.
@@ -200,7 +200,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block Chunk
   /v0/block/{block_height}/headers:
     get:
-      description: Fetch the top-level block object for a finalized block, including the block header and chunk summaries.
+      description: Fetch only a finalized block's header and chunk summaries — no per-shard payload.
       operationId: get_block_headers
       parameters:
       - description: NEAR block height to retrieve.
@@ -261,7 +261,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block Headers
   /v0/block/{block_height}/shard/{shard_id}:
     get:
-      description: Fetch a single shard document for a given finalized block and shard ID.
+      description: Fetch one shard's full payload at a chosen block — chunk plus state changes and produced receipts.
       operationId: get_shard
       parameters:
       - description: NEAR block height to retrieve.
@@ -329,7 +329,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block Shard
   /v0/block_opt/{block_height}:
     get:
-      description: Fetch an optimistic block document when the endpoint can serve it directly, or follow the documented redirect behavior when the deployment hands off to finalized or archive infrastructure.
+      description: Fetch an optimistic (not-yet-final) block at a chosen height — may redirect once the optimistic window has finalized.
       operationId: get_block_optimistic
       parameters:
       - description: NEAR block height to retrieve.
@@ -390,7 +390,7 @@ paths:
       x-fastnear-title: NEAR Data API - Optimistic Block
   /v0/first_block:
     get:
-      description: This endpoint redirects to the canonical first block URL for the selected network.
+      description: Redirect to the chain's first post-genesis block — a starting cursor for indexers backfilling from the beginning.
       operationId: get_first_block
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
@@ -429,7 +429,7 @@ paths:
       x-fastnear-title: NEAR Data API - First Block
   /v0/last_block/final:
     get:
-      description: This endpoint redirects to the latest finalized block URL for the active deployment.
+      description: Redirect to the most recent finalized block — the chain-tip cursor once consensus has settled.
       operationId: get_last_block_final
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
@@ -474,7 +474,7 @@ paths:
       x-fastnear-title: NEAR Data API - Last Final Block
   /v0/last_block/optimistic:
     get:
-      description: This endpoint redirects to the latest optimistic block URL for the active deployment.
+      description: Redirect to the most recent optimistic block — the freshest-possible tip, ahead of final settlement.
       operationId: get_last_block_optimistic
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -33,7 +33,7 @@ openapi: 3.0.3
 paths:
   /health:
     get:
-      description: Returns `ok` when the current deployment is healthy and `unhealthy` when the latest indexed block is too stale. Invalid API keys can be rejected upstream before the request reaches the app.
+      description: Check whether the neardata service is healthy for the current deployment.
       operationId: get_health
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
@@ -71,7 +71,7 @@ paths:
       x-fastnear-title: NEAR Data API - Health
   /v0/block/{block_height}:
     get:
-      description: Returns the finalized block document for the requested height, or `null` when the block does not exist within the requested archive segment. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      description: Fetch the finalized block document for a given height, including all chunks and shard data.
       operationId: get_block
       parameters:
       - description: NEAR block height to retrieve.
@@ -132,7 +132,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block
   /v0/block/{block_height}/chunk/{shard_id}:
     get:
-      description: Returns the chunk object for the requested shard ID, or `null` when that chunk is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      description: Fetch a single chunk for a given finalized block and shard ID.
       operationId: get_chunk
       parameters:
       - description: NEAR block height to retrieve.
@@ -200,7 +200,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block Chunk
   /v0/block/{block_height}/headers:
     get:
-      description: Returns the `block` object extracted from the full block response, not just the nested `header` sub-object. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      description: Fetch the top-level block object for a finalized block, including the block header and chunk summaries.
       operationId: get_block_headers
       parameters:
       - description: NEAR block height to retrieve.
@@ -261,7 +261,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block Headers
   /v0/block/{block_height}/shard/{shard_id}:
     get:
-      description: Returns the shard object for the requested shard ID, or `null` when that shard is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      description: Fetch a single shard document for a given finalized block and shard ID.
       operationId: get_shard
       parameters:
       - description: NEAR block height to retrieve.
@@ -329,7 +329,7 @@ paths:
       x-fastnear-title: NEAR Data API - Block Shard
   /v0/block_opt/{block_height}:
     get:
-      description: Returns an optimistic block document when the deployment can serve it directly. Older or archive-only heights may redirect to a canonical finalized or archive URL instead.
+      description: Fetch an optimistic block document when the endpoint can serve it directly, or follow the documented redirect behavior when the deployment hands off to finalized or archive infrastructure.
       operationId: get_block_optimistic
       parameters:
       - description: NEAR block height to retrieve.
@@ -390,7 +390,7 @@ paths:
       x-fastnear-title: NEAR Data API - Optimistic Block
   /v0/first_block:
     get:
-      description: Returns a redirect to the canonical first block URL for the selected deployment. Clients that automatically follow redirects will receive the full block document instead.
+      description: This endpoint redirects to the canonical first block URL for the selected network.
       operationId: get_first_block
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
@@ -429,7 +429,7 @@ paths:
       x-fastnear-title: NEAR Data API - First Block
   /v0/last_block/final:
     get:
-      description: Returns a redirect to the canonical latest finalized block URL for the current deployment. Clients that automatically follow redirects will receive the full block document instead.
+      description: This endpoint redirects to the latest finalized block URL for the active deployment.
       operationId: get_last_block_final
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
@@ -474,7 +474,7 @@ paths:
       x-fastnear-title: NEAR Data API - Last Final Block
   /v0/last_block/optimistic:
     get:
-      description: Returns a redirect to the canonical latest optimistic block URL for the current deployment. Clients that automatically follow redirects will receive the resulting block document instead.
+      description: This endpoint redirects to the latest optimistic block URL for the active deployment.
       operationId: get_last_block_optimistic
       parameters:
       - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,524 @@
+components:
+  schemas:
+    BlockErrorResponse:
+      additionalProperties: false
+      properties:
+        error:
+          type: string
+        type:
+          $ref: '#/components/schemas/BlockErrorType'
+      required:
+      - error
+      - type
+      type: object
+    BlockErrorType:
+      enum:
+      - BLOCK_HEIGHT_TOO_HIGH
+      - BLOCK_HEIGHT_TOO_LOW
+      - BLOCK_DOES_NOT_EXIST
+      type: string
+    HealthResponse:
+      additionalProperties: false
+      properties:
+        status:
+          type: string
+      required:
+      - status
+      type: object
+info:
+  description: Cached and archived NEAR block data with redirect helpers for first-block and latest-block workflows. Some block-family routes may redirect depending on archive or freshness topology.
+  title: NEAR Data API
+  version: 3.0.3
+openapi: 3.0.3
+paths:
+  /health:
+    get:
+      description: Returns `ok` when the current deployment is healthy and `unhealthy` when the latest indexed block is too stale. Invalid API keys can be rejected upstream before the request reaches the app.
+      operationId: get_health
+      parameters:
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                status: ok
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+          description: Health payload
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Get service health
+      tags:
+      - system
+      x-fastnear-slug: health
+      x-fastnear-title: NEAR Data API - Health
+  /v0/block/{block_height}:
+    get:
+      description: Returns the finalized block document for the requested height, or `null` when the block does not exist within the requested archive segment. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      operationId: get_block
+      parameters:
+      - description: NEAR block height to retrieve.
+        example: '9820210'
+        in: path
+        name: block_height
+        required: true
+        schema:
+          type: string
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Full block document as served by neardata, including `block` and `shards`.
+                nullable: true
+                type: object
+          description: Requested document, or `null` when the selected slice is absent
+        '302':
+          description: Redirect to a canonical archive or finalized block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '404':
+          content:
+            application/json:
+              example:
+                error: The block does not exist in this archive range
+                type: BLOCK_DOES_NOT_EXIST
+              schema:
+                $ref: '#/components/schemas/BlockErrorResponse'
+          description: Structured block-height error
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Fetch a finalized block by height
+      tags:
+      - blocks
+      x-fastnear-slug: block
+      x-fastnear-title: NEAR Data API - Block
+  /v0/block/{block_height}/chunk/{shard_id}:
+    get:
+      description: Returns the chunk object for the requested shard ID, or `null` when that chunk is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      operationId: get_chunk
+      parameters:
+      - description: NEAR block height to retrieve.
+        example: '9820210'
+        in: path
+        name: block_height
+        required: true
+        schema:
+          type: string
+      - description: Shard ID whose chunk should be returned.
+        example: '0'
+        in: path
+        name: shard_id
+        required: true
+        schema:
+          type: string
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Chunk object for the requested shard ID.
+                nullable: true
+                type: object
+          description: Requested document, or `null` when the selected slice is absent
+        '302':
+          description: Redirect to a canonical archive or finalized block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '404':
+          content:
+            application/json:
+              example:
+                error: The block does not exist in this archive range
+                type: BLOCK_DOES_NOT_EXIST
+              schema:
+                $ref: '#/components/schemas/BlockErrorResponse'
+          description: Structured block-height error
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Fetch one chunk from a finalized block
+      tags:
+      - blocks
+      x-fastnear-slug: block_chunk
+      x-fastnear-title: NEAR Data API - Block Chunk
+  /v0/block/{block_height}/headers:
+    get:
+      description: Returns the `block` object extracted from the full block response, not just the nested `header` sub-object. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      operationId: get_block_headers
+      parameters:
+      - description: NEAR block height to retrieve.
+        example: '9820210'
+        in: path
+        name: block_height
+        required: true
+        schema:
+          type: string
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Block-level object returned by `/headers`, corresponding to the full response's `block` field.
+                nullable: true
+                type: object
+          description: Requested document, or `null` when the selected slice is absent
+        '302':
+          description: Redirect to a canonical archive or finalized block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '404':
+          content:
+            application/json:
+              example:
+                error: The block does not exist in this archive range
+                type: BLOCK_DOES_NOT_EXIST
+              schema:
+                $ref: '#/components/schemas/BlockErrorResponse'
+          description: Structured block-height error
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Fetch the block-level object for a finalized block
+      tags:
+      - blocks
+      x-fastnear-slug: block_headers
+      x-fastnear-title: NEAR Data API - Block Headers
+  /v0/block/{block_height}/shard/{shard_id}:
+    get:
+      description: Returns the shard object for the requested shard ID, or `null` when that shard is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.
+      operationId: get_shard
+      parameters:
+      - description: NEAR block height to retrieve.
+        example: '9820210'
+        in: path
+        name: block_height
+        required: true
+        schema:
+          type: string
+      - description: Shard ID to return.
+        example: '0'
+        in: path
+        name: shard_id
+        required: true
+        schema:
+          type: string
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Shard object for the requested shard ID.
+                nullable: true
+                type: object
+          description: Requested document, or `null` when the selected slice is absent
+        '302':
+          description: Redirect to a canonical archive or finalized block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '404':
+          content:
+            application/json:
+              example:
+                error: The block does not exist in this archive range
+                type: BLOCK_DOES_NOT_EXIST
+              schema:
+                $ref: '#/components/schemas/BlockErrorResponse'
+          description: Structured block-height error
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Fetch one shard from a finalized block
+      tags:
+      - blocks
+      x-fastnear-slug: block_shard
+      x-fastnear-title: NEAR Data API - Block Shard
+  /v0/block_opt/{block_height}:
+    get:
+      description: Returns an optimistic block document when the deployment can serve it directly. Older or archive-only heights may redirect to a canonical finalized or archive URL instead.
+      operationId: get_block_optimistic
+      parameters:
+      - description: NEAR block height to retrieve.
+        example: '9820210'
+        in: path
+        name: block_height
+        required: true
+        schema:
+          type: string
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Full block document as served by neardata, including `block` and `shards`.
+                nullable: true
+                type: object
+          description: Requested document, or `null` when the selected slice is absent
+        '302':
+          description: Redirect to a canonical archive or finalized block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '404':
+          content:
+            application/json:
+              example:
+                error: The block does not exist in this archive range
+                type: BLOCK_DOES_NOT_EXIST
+              schema:
+                $ref: '#/components/schemas/BlockErrorResponse'
+          description: Structured block-height error
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Fetch an optimistic block by height
+      tags:
+      - blocks
+      x-fastnear-slug: block_optimistic
+      x-fastnear-title: NEAR Data API - Optimistic Block
+  /v0/first_block:
+    get:
+      description: Returns a redirect to the canonical first block URL for the selected deployment. Clients that automatically follow redirects will receive the full block document instead.
+      operationId: get_first_block
+      parameters:
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Full block document as served by neardata, including `block` and `shards`.
+                nullable: true
+                type: object
+          description: Full block document returned after automatic redirect following
+        '302':
+          description: Redirect to the canonical first block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+      summary: Redirect to the first block after genesis
+      tags:
+      - blocks
+      x-fastnear-slug: first_block
+      x-fastnear-title: NEAR Data API - First Block
+  /v0/last_block/final:
+    get:
+      description: Returns a redirect to the canonical latest finalized block URL for the current deployment. Clients that automatically follow redirects will receive the full block document instead.
+      operationId: get_last_block_final
+      parameters:
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Full block document as served by neardata, including `block` and `shards`.
+                nullable: true
+                type: object
+          description: Full block document returned after automatic redirect following
+        '302':
+          description: Redirect to the latest block block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Redirect to the latest finalized block
+      tags:
+      - blocks
+      x-fastnear-slug: last_block_final
+      x-fastnear-title: NEAR Data API - Last Final Block
+  /v0/last_block/optimistic:
+    get:
+      description: Returns a redirect to the canonical latest optimistic block URL for the current deployment. Clients that automatically follow redirects will receive the resulting block document instead.
+      operationId: get_last_block_optimistic
+      parameters:
+      - description: Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.
+        in: query
+        name: apiKey
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                description: Full block document as served by neardata, including `block` and `shards`.
+                nullable: true
+                type: object
+          description: Full block document returned after automatic redirect following
+        '302':
+          description: Redirect to the latest block block URL
+          headers:
+            Location:
+              schema:
+                type: string
+        '401':
+          content:
+            text/plain:
+              example: Unauthorized
+              schema:
+                type: string
+          description: Invalid or unauthorized API key
+        '500':
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Cache or internal data error
+      summary: Redirect to the latest optimistic block
+      tags:
+      - blocks
+      x-fastnear-slug: last_block_optimistic
+      x-fastnear-title: NEAR Data API - Last Optimistic Block
+servers:
+- description: Mainnet
+  url: https://mainnet.neardata.xyz
+- description: Testnet
+  url: https://testnet.neardata.xyz

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -75,7 +75,7 @@ paths:
       operationId: get_block
       parameters:
       - description: NEAR block height to retrieve.
-        example: '9820210'
+        example: '50000000'
         in: path
         name: block_height
         required: true
@@ -136,7 +136,7 @@ paths:
       operationId: get_chunk
       parameters:
       - description: NEAR block height to retrieve.
-        example: '9820210'
+        example: '50000000'
         in: path
         name: block_height
         required: true
@@ -204,7 +204,7 @@ paths:
       operationId: get_block_headers
       parameters:
       - description: NEAR block height to retrieve.
-        example: '9820210'
+        example: '50000000'
         in: path
         name: block_height
         required: true
@@ -265,7 +265,7 @@ paths:
       operationId: get_shard
       parameters:
       - description: NEAR block height to retrieve.
-        example: '9820210'
+        example: '50000000'
         in: path
         name: block_height
         required: true
@@ -333,7 +333,7 @@ paths:
       operationId: get_block_optimistic
       parameters:
       - description: NEAR block height to retrieve.
-        example: '9820210'
+        example: '50000000'
         in: path
         name: block_height
         required: true

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,5 +1,80 @@
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: '#/components/schemas/ActionReceiptDocument'
+      required:
+      - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: '#/components/schemas/ActionDocument'
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: '#/components/schemas/OutputDataReceiverDocument'
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+      - actions
+      - gas_price
+      - input_data_ids
+      - is_promise_yield
+      - output_data_receivers
+      - signer_id
+      - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: '#/components/schemas/BlockEnvelope'
+        shards:
+          items:
+            $ref: '#/components/schemas/ShardDocument'
+          type: array
+      required:
+      - block
+      - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: '#/components/schemas/ChunkHeader'
+          type: array
+        header:
+          $ref: '#/components/schemas/BlockHeader'
+      required:
+      - author
+      - chunks
+      - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -17,6 +92,224 @@ components:
       - BLOCK_HEIGHT_TOO_LOW
       - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: '#/components/schemas/ChunkHeader'
+        receipts:
+          items:
+            $ref: '#/components/schemas/ReceiptDocument'
+          type: array
+        transactions:
+          items:
+            $ref: '#/components/schemas/ChunkTransactionWrapper'
+          type: array
+      required:
+      - author
+      - header
+      - receipts
+      - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: '#/components/schemas/ExecutionWithReceipt'
+        transaction:
+          $ref: '#/components/schemas/SignedTransactionDocument'
+      required:
+      - outcome
+      - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: '#/components/schemas/DataReceiptDocument'
+      required:
+      - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+      - data
+      - data_id
+      - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: '#/components/schemas/ExecutionOutcomeSummary'
+        proof:
+          items:
+            $ref: '#/components/schemas/ExecutionProofItem'
+          type: array
+      required:
+      - block_hash
+      - id
+      - outcome
+      - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+      - $ref: '#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId'
+      - $ref: '#/components/schemas/ExecutionOutcomeStatusSuccessValue'
+      - $ref: '#/components/schemas/ExecutionOutcomeStatusFailure'
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+      - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+      - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+      - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: '#/components/schemas/ExecutionOutcomeStatus'
+        tokens_burnt:
+          type: string
+      required:
+      - executor_id
+      - gas_burnt
+      - logs
+      - metadata
+      - receipt_ids
+      - status
+      - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: '#/components/schemas/ExecutionOutcomeDocument'
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/ReceiptDocument'
+          - $ref: '#/components/schemas/OmittedReceiptDocument'
+          type: object
+        tx_hash:
+          type: string
+      required:
+      - execution_outcome
+      - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -24,6 +317,226 @@ components:
           type: string
       required:
       - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+      - data_id
+      - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+      - $ref: '#/components/schemas/ActionReceiptBody'
+      - $ref: '#/components/schemas/DataReceiptBody'
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: '#/components/schemas/ReceiptBody'
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+      - predecessor_id
+      - priority
+      - receipt
+      - receipt_id
+      - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: '#/components/schemas/ChunkDocument'
+        receipt_execution_outcomes:
+          items:
+            $ref: '#/components/schemas/ExecutionWithReceipt'
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: '#/components/schemas/StateChangeItem'
+          type: array
+      required:
+      - chunk
+      - receipt_execution_outcomes
+      - shard_id
+      - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: '#/components/schemas/ActionDocument'
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+      - actions
+      - hash
+      - nonce
+      - priority_fee
+      - public_key
+      - receiver_id
+      - signature
+      - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+      - $ref: '#/components/schemas/StateChangeCauseTransactionProcessing'
+      - $ref: '#/components/schemas/StateChangeCauseReceiptProcessing'
+      - $ref: '#/components/schemas/StateChangeCauseActionReceiptGasReward'
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+      - receipt_hash
+      - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+      - receipt_hash
+      - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+      - tx_hash
+      - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: '#/components/schemas/StateChangeCause'
+        change:
+          $ref: '#/components/schemas/StateChangeValue'
+        type:
+          type: string
+      required:
+      - cause
+      - change
+      - type
+      type: object
+    StateChangeValue:
+      oneOf:
+      - $ref: '#/components/schemas/StateChangeValueAccountUpdate'
+      - $ref: '#/components/schemas/StateChangeValueAccessKeyUpdate'
+      - $ref: '#/components/schemas/StateChangeValueDataUpdate'
+      - $ref: '#/components/schemas/StateChangeValueDataDeletion'
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+      - access_key
+      - account_id
+      - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+      - account_id
+      - amount
+      - code_hash
+      - locked
+      - storage_paid_at
+      - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+      - account_id
+      - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+      - account_id
+      - key_base64
+      - value_base64
       type: object
 info:
   description: Cached and archived NEAR block data with redirect helpers for first-block and latest-block workflows. Some block-family routes may redirect depending on archive or freshness topology.
@@ -92,10 +605,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: '#/components/schemas/BlockDocument'
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         '302':
           description: Redirect to a canonical archive or finalized block URL
@@ -160,10 +671,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Chunk object for the requested shard ID.
+                $ref: '#/components/schemas/ChunkDocument'
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         '302':
           description: Redirect to a canonical archive or finalized block URL
@@ -221,10 +730,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Block-level object returned by `/headers`, corresponding to the full response's `block` field.
+                $ref: '#/components/schemas/BlockEnvelope'
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         '302':
           description: Redirect to a canonical archive or finalized block URL
@@ -289,10 +796,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Shard object for the requested shard ID.
+                $ref: '#/components/schemas/ShardDocument'
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         '302':
           description: Redirect to a canonical archive or finalized block URL
@@ -350,10 +855,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: '#/components/schemas/BlockDocument'
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         '302':
           description: Redirect to a canonical archive or finalized block URL
@@ -404,10 +907,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: '#/components/schemas/BlockDocument'
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         '302':
           description: Redirect to the canonical first block URL
@@ -443,10 +944,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: '#/components/schemas/BlockDocument'
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         '302':
           description: Redirect to the latest block block URL
@@ -488,10 +987,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: '#/components/schemas/BlockDocument'
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         '302':
           description: Redirect to the latest block block URL

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,9 +2,9 @@ use crate::cache::set_multiple_blocks_async;
 use crate::reader::read_blocks;
 use crate::types::*;
 use crate::*;
-use actix_web::ResponseError;
+use actix_web::http::header;
+use actix_web::{get, HttpRequest, HttpResponse, Responder, ResponseError};
 use reqwest::header::HeaderName;
-use serde_json::json;
 use std::fmt;
 use std::str::FromStr;
 use std::time::Duration;
@@ -406,10 +406,10 @@ pub mod v0 {
                         header::CACHE_CONTROL,
                         format!("public, max-age={}", 24 * 60 * 60),
                     ))
-                    .json(json!({
-                        "error": "Block height is too high",
-                        "type": "BLOCK_HEIGHT_TOO_HIGH"
-                    })),
+                    .json(BlockErrorResponse::new(
+                        "Block height is too high",
+                        BlockErrorType::BlockHeightTooHigh,
+                    )),
             );
         }
         if block_height < app_state.genesis_block_height {
@@ -419,10 +419,10 @@ pub mod v0 {
                         header::CACHE_CONTROL,
                         format!("public, max-age={}", 24 * 60 * 60),
                     ))
-                    .json(json!({
-                        "error": "Block height is before the genesis",
-                        "type": "BLOCK_HEIGHT_TOO_LOW"
-                    })),
+                    .json(BlockErrorResponse::new(
+                        "Block height is before the genesis",
+                        BlockErrorType::BlockHeightTooLow,
+                    )),
             );
         }
         None
@@ -565,10 +565,10 @@ pub mod v0 {
         if app_state.is_latest {
             if block_height > last_block_height + MAX_WAIT_BLOCKS {
                 return Ok(Some(BlockOrResponse::Response(
-                    HttpResponse::NotFound().json(json!({
-                        "error": "The block is too far in the future",
-                        "type": "BLOCK_DOES_NOT_EXIST"
-                    })),
+                    HttpResponse::NotFound().json(BlockErrorResponse::new(
+                        "The block is too far in the future",
+                        BlockErrorType::BlockDoesNotExist,
+                    )),
                 )));
             }
 
@@ -668,7 +668,9 @@ pub mod v0 {
 #[get("/health")]
 pub async fn health(app_state: web::Data<AppState>) -> Result<impl Responder, ServiceError> {
     if !app_state.is_latest {
-        return Ok(HttpResponse::Ok().json(json!({"status": "ok"})));
+        return Ok(HttpResponse::Ok().json(HealthResponse {
+            status: "ok".to_string(),
+        }));
     }
     let chain_id = app_state.chain_id;
     let finality = Finality::Final;
@@ -702,7 +704,9 @@ pub async fn health(app_state: web::Data<AppState>) -> Result<impl Responder, Se
                 .unwrap_or_default();
             let sync_latency_ms = now.as_nanos().saturating_sub(t_nano) / 1_000_000;
             if sync_latency_ms > app_state.max_healthy_latency_ms {
-                return Ok(HttpResponse::Ok().json(json!({"status": "unhealthy"})));
+                return Ok(HttpResponse::Ok().json(HealthResponse {
+                    status: "unhealthy".to_string(),
+                }));
             }
         }
         _ => {
@@ -712,5 +716,7 @@ pub async fn health(app_state: web::Data<AppState>) -> Result<impl Responder, Se
         }
     }
 
-    Ok(HttpResponse::Ok().json(json!({"status": "ok"})))
+    Ok(HttpResponse::Ok().json(HealthResponse {
+        status: "ok".to_string(),
+    }))
 }

--- a/src/bin/generate-openapi.rs
+++ b/src/bin/generate-openapi.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "openapi")]
+fn main() -> anyhow::Result<()> {
+    let check = std::env::args().skip(1).any(|arg| arg == "--check");
+    neardata_server::openapi::generate(check)
+}
+
+#[cfg(not(feature = "openapi"))]
+fn main() {
+    eprintln!("This binary requires the `openapi` feature.");
+    std::process::exit(1);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,68 @@
+pub mod api;
+pub mod cache;
+#[cfg(feature = "openapi")]
+pub mod openapi;
+pub mod reader;
+pub mod types;
+
+use actix_web::{web, HttpResponse, Responder, Scope};
+
+use crate::types::{BlockHeight, ChainId};
+
+pub static INDEX_HTML: &str = include_str!("../static/index.html");
+pub static SKILL_MD: &str = include_str!("../static/skill.md");
+
+#[derive(Clone)]
+pub struct ReadConfig {
+    pub path: String,
+    pub save_every_n: u64,
+}
+
+#[derive(Clone)]
+pub struct ArchiveConfig {
+    pub archive_boundaries: Vec<BlockHeight>,
+    pub domain_name: String,
+    /// The index of the archive boundary that this node is responsible for.
+    /// E.g. If there are 2 boundaries:
+    /// - `0` -> means from genesis to the first archive boundary (exclusive).
+    /// - `1` -> means from the first archive boundary to the second archive boundary (exclusive).
+    /// - `2` -> means from the second archive boundary to the blockchain head.
+    pub archive_index: usize,
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub redis_client: redis::Client,
+    pub read_config: Option<ReadConfig>,
+    pub chain_id: ChainId,
+    pub genesis_block_height: BlockHeight,
+    /// Whether this node has the latest blocks and uses archive files.
+    /// If not, it means this is an archive node.
+    pub is_latest: bool,
+    /// Whether this node has the freshest blocks, but doesn't use archive files.
+    pub is_fresh: bool,
+    pub archive_config: Option<ArchiveConfig>,
+    pub max_healthy_latency_ms: u128,
+}
+
+pub async fn serve_index() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(INDEX_HTML)
+}
+
+pub async fn serve_skill() -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/markdown; charset=utf-8")
+        .body(SKILL_MD)
+}
+
+pub fn api_v0_scope() -> Scope {
+    web::scope("/v0")
+        .service(api::v0::get_first_block)
+        .service(api::v0::get_block)
+        .service(api::v0::get_last_block)
+        .service(api::v0::get_block_headers)
+        .service(api::v0::get_shard)
+        .service(api::v0::get_chunk)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,64 +1,15 @@
-mod api;
-mod cache;
-mod reader;
-mod types;
-
 use dotenv::dotenv;
 use std::env;
 
-use crate::types::{BlockHeight, ChainId};
 use actix_cors::Cors;
 use actix_web::http::header;
-use actix_web::{get, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use actix_web::{middleware, web, App, HttpServer};
+use neardata_server::api;
+use neardata_server::types::{BlockHeight, ChainId};
+use neardata_server::{
+    api_v0_scope, serve_index, serve_skill, AppState, ArchiveConfig, ReadConfig,
+};
 use tracing_subscriber::EnvFilter;
-
-pub static INDEX_HTML: &str = include_str!("../static/index.html");
-pub static SKILL_MD: &str = include_str!("../static/skill.md");
-
-#[derive(Clone)]
-pub struct ReadConfig {
-    pub path: String,
-    pub save_every_n: u64,
-}
-
-#[derive(Clone)]
-pub struct ArchiveConfig {
-    pub archive_boundaries: Vec<BlockHeight>,
-    pub domain_name: String,
-    /// The index of the archive boundary that this node is responsible for.
-    /// E.g. If there are 2 boundaries:
-    /// - `0` -> means from genesis to the first archive boundary (exclusive).
-    /// - `1` -> means from the first archive boundary to the second archive boundary (exclusive).
-    /// - `2` -> means from the second archive boundary to the blockchain head.
-    pub archive_index: usize,
-}
-
-#[derive(Clone)]
-pub struct AppState {
-    pub redis_client: redis::Client,
-    pub read_config: Option<ReadConfig>,
-    pub chain_id: ChainId,
-    pub genesis_block_height: BlockHeight,
-    /// Whether this node has the latest blocks and uses archive files.
-    /// If not, it means this is an archive node.
-    pub is_latest: bool,
-    /// Whether this node has the freshest blocks, but doesn't use archive files
-    pub is_fresh: bool,
-    pub archive_config: Option<ArchiveConfig>,
-    pub max_healthy_latency_ms: u128,
-}
-
-async fn greet() -> impl Responder {
-    HttpResponse::Ok()
-        .content_type("text/html; charset=utf-8")
-        .body(INDEX_HTML)
-}
-
-async fn skill() -> impl Responder {
-    HttpResponse::Ok()
-        .content_type("text/markdown; charset=utf-8")
-        .body(SKILL_MD)
-}
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -132,13 +83,6 @@ async fn main() -> std::io::Result<()> {
             .max_age(3600)
             .supports_credentials();
 
-        let api_v0 = web::scope("/v0")
-            .service(api::v0::get_first_block)
-            .service(api::v0::get_block)
-            .service(api::v0::get_last_block)
-            .service(api::v0::get_block_headers)
-            .service(api::v0::get_shard)
-            .service(api::v0::get_chunk);
         App::new()
             .app_data(web::Data::new(AppState {
                 redis_client: redis_client.clone(),
@@ -156,10 +100,10 @@ async fn main() -> std::io::Result<()> {
             ))
             .wrap(tracing_actix_web::TracingLogger::default())
             .service(api::health)
-            .service(api_v0)
-            .route("/", web::get().to(greet))
-            .route("/skill.md", web::get().to(skill))
-            .route("/SKILL.md", web::get().to(skill))
+            .service(api_v0_scope())
+            .route("/", web::get().to(serve_index))
+            .route("/skill.md", web::get().to(serve_skill))
+            .route("/SKILL.md", web::get().to(serve_skill))
     })
     .bind(format!("127.0.0.1:{}", env::var("PORT").unwrap()))?
     .run()

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -340,7 +340,7 @@ fn block_height_parameter() -> Value {
         "schema": {
             "type": "string"
         },
-        "example": "9820210"
+        "example": "50000000"
     })
 }
 

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,0 +1,430 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use fastnear_openapi_generator::{write_or_check_yaml, SchemaRegistry};
+use serde_json::{json, Value};
+
+use crate::types::{BlockErrorResponse, HealthResponse};
+
+const API_VERSION: &str = "3.0.3";
+
+pub fn generate(check: bool) -> Result<()> {
+    let output_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("openapi");
+    let mut registry = SchemaRegistry::openapi3();
+    let health = registry.schema_ref::<HealthResponse>();
+    let block_error = registry.schema_ref::<BlockErrorResponse>();
+    let components = registry.into_components();
+
+    let doc = json!({
+        "openapi": API_VERSION,
+        "info": {
+            "title": "NEAR Data API",
+            "version": API_VERSION,
+            "description": "Cached and archived NEAR block data with redirect helpers for first-block and latest-block workflows. Some block-family routes may redirect depending on archive or freshness topology."
+        },
+        "servers": [
+            {
+                "url": "https://mainnet.neardata.xyz",
+                "description": "Mainnet"
+            },
+            {
+                "url": "https://testnet.neardata.xyz",
+                "description": "Testnet"
+            }
+        ],
+        "paths": {
+            "/health": {
+                "get": health_operation(health)
+            },
+            "/v0/first_block": {
+                "get": first_block_operation()
+            },
+            "/v0/block/{block_height}": {
+                "get": block_operation(
+                    "block",
+                    "NEAR Data API - Block",
+                    "get_block",
+                    "Fetch a finalized block by height",
+                    "Returns the finalized block document for the requested height, or `null` when the block does not exist within the requested archive segment. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    block_document_schema(),
+                    vec![block_height_parameter()],
+                    block_error.clone()
+                )
+            },
+            "/v0/block/{block_height}/headers": {
+                "get": block_operation(
+                    "block_headers",
+                    "NEAR Data API - Block Headers",
+                    "get_block_headers",
+                    "Fetch the block-level object for a finalized block",
+                    "Returns the `block` object extracted from the full block response, not just the nested `header` sub-object. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    headers_document_schema(),
+                    vec![block_height_parameter()],
+                    block_error.clone()
+                )
+            },
+            "/v0/block/{block_height}/chunk/{shard_id}": {
+                "get": block_operation(
+                    "block_chunk",
+                    "NEAR Data API - Block Chunk",
+                    "get_chunk",
+                    "Fetch one chunk from a finalized block",
+                    "Returns the chunk object for the requested shard ID, or `null` when that chunk is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    chunk_document_schema(),
+                    vec![block_height_parameter(), shard_id_parameter("Shard ID whose chunk should be returned.")],
+                    block_error.clone()
+                )
+            },
+            "/v0/block/{block_height}/shard/{shard_id}": {
+                "get": block_operation(
+                    "block_shard",
+                    "NEAR Data API - Block Shard",
+                    "get_shard",
+                    "Fetch one shard from a finalized block",
+                    "Returns the shard object for the requested shard ID, or `null` when that shard is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    shard_document_schema(),
+                    vec![block_height_parameter(), shard_id_parameter("Shard ID to return.")],
+                    block_error.clone()
+                )
+            },
+            "/v0/block_opt/{block_height}": {
+                "get": block_operation(
+                    "block_optimistic",
+                    "NEAR Data API - Optimistic Block",
+                    "get_block_optimistic",
+                    "Fetch an optimistic block by height",
+                    "Returns an optimistic block document when the deployment can serve it directly. Older or archive-only heights may redirect to a canonical finalized or archive URL instead.",
+                    block_document_schema(),
+                    vec![block_height_parameter()],
+                    block_error.clone()
+                )
+            },
+            "/v0/last_block/final": {
+                "get": last_block_operation(
+                    "last_block_final",
+                    "NEAR Data API - Last Final Block",
+                    "get_last_block_final",
+                    "Redirect to the latest finalized block",
+                    "Returns a redirect to the canonical latest finalized block URL for the current deployment. Clients that automatically follow redirects will receive the full block document instead."
+                )
+            },
+            "/v0/last_block/optimistic": {
+                "get": last_block_operation(
+                    "last_block_optimistic",
+                    "NEAR Data API - Last Optimistic Block",
+                    "get_last_block_optimistic",
+                    "Redirect to the latest optimistic block",
+                    "Returns a redirect to the canonical latest optimistic block URL for the current deployment. Clients that automatically follow redirects will receive the resulting block document instead."
+                )
+            }
+        },
+        "components": {
+            "schemas": components
+        }
+    });
+
+    write_or_check_yaml(output_root.join("openapi.yaml"), &doc, check)?;
+    Ok(())
+}
+
+fn health_operation(health_schema: Value) -> Value {
+    json!({
+        "operationId": "get_health",
+        "summary": "Get service health",
+        "description": "Returns `ok` when the current deployment is healthy and `unhealthy` when the latest indexed block is too stale. Invalid API keys can be rejected upstream before the request reaches the app.",
+        "tags": ["system"],
+        "x-fastnear-slug": "health",
+        "x-fastnear-title": "NEAR Data API - Health",
+        "parameters": [api_key_parameter()],
+        "responses": {
+            "200": json_response(
+                "Health payload",
+                health_schema,
+                Some(json!({ "status": "ok" }))
+            ),
+            "401": plain_text_response("Invalid or unauthorized API key", Some("Unauthorized")),
+            "500": json_string_response("Cache or internal data error")
+        }
+    })
+}
+
+fn first_block_operation() -> Value {
+    json!({
+        "operationId": "get_first_block",
+        "summary": "Redirect to the first block after genesis",
+        "description": "Returns a redirect to the canonical first block URL for the selected deployment. Clients that automatically follow redirects will receive the full block document instead.",
+        "tags": ["blocks"],
+        "x-fastnear-slug": "first_block",
+        "x-fastnear-title": "NEAR Data API - First Block",
+        "parameters": [api_key_parameter()],
+        "responses": {
+            "200": json_response(
+                "Full block document returned after automatic redirect following",
+                block_document_schema(),
+                None
+            ),
+            "302": redirect_response("Redirect to the canonical first block URL"),
+            "401": plain_text_response("Invalid or unauthorized API key", Some("Unauthorized"))
+        }
+    })
+}
+
+fn last_block_operation(
+    slug: &str,
+    title: &str,
+    operation_id: &str,
+    summary: &str,
+    description: &str,
+) -> Value {
+    json!({
+        "operationId": operation_id,
+        "summary": summary,
+        "description": description,
+        "tags": ["blocks"],
+        "x-fastnear-slug": slug,
+        "x-fastnear-title": title,
+        "parameters": [api_key_parameter()],
+        "responses": {
+            "200": json_response(
+                "Full block document returned after automatic redirect following",
+                block_document_schema(),
+                None
+            ),
+            "302": redirect_response(format!("Redirect to the latest {} block URL", summary.split_whitespace().last().unwrap_or("block")).as_str()),
+            "401": plain_text_response("Invalid or unauthorized API key", Some("Unauthorized")),
+            "500": json_string_response("Cache or internal data error")
+        }
+    })
+}
+
+fn block_operation(
+    slug: &str,
+    title: &str,
+    operation_id: &str,
+    summary: &str,
+    description: &str,
+    response_schema: Value,
+    mut parameters: Vec<Value>,
+    block_error_schema: Value,
+) -> Value {
+    parameters.push(api_key_parameter());
+    json!({
+        "operationId": operation_id,
+        "summary": summary,
+        "description": description,
+        "tags": ["blocks"],
+        "x-fastnear-slug": slug,
+        "x-fastnear-title": title,
+        "parameters": parameters,
+        "responses": {
+            "200": json_response(
+                "Requested document, or `null` when the selected slice is absent",
+                response_schema,
+                None
+            ),
+            "302": redirect_response("Redirect to a canonical archive or finalized block URL"),
+            "401": plain_text_response("Invalid or unauthorized API key", Some("Unauthorized")),
+            "404": json_response(
+                "Structured block-height error",
+                block_error_schema,
+                Some(json!({
+                    "error": "The block does not exist in this archive range",
+                    "type": "BLOCK_DOES_NOT_EXIST"
+                }))
+            ),
+            "500": json_string_response("Cache or internal data error")
+        }
+    })
+}
+
+fn json_response(description: &str, schema: Value, example: Option<Value>) -> Value {
+    let mut content = json!({
+        "application/json": {
+            "schema": schema
+        }
+    });
+
+    if let Some(example) = example {
+        content["application/json"]["example"] = example;
+    }
+
+    json!({
+        "description": description,
+        "content": content
+    })
+}
+
+fn json_string_response(description: &str) -> Value {
+    json_response(description, json!({ "type": "string" }), None)
+}
+
+fn plain_text_response(description: &str, example: Option<&str>) -> Value {
+    let mut content = json!({
+        "text/plain": {
+            "schema": {
+                "type": "string"
+            }
+        }
+    });
+
+    if let Some(example) = example {
+        content["text/plain"]["example"] = json!(example);
+    }
+
+    json!({
+        "description": description,
+        "content": content
+    })
+}
+
+fn redirect_response(description: &str) -> Value {
+    json!({
+        "description": description,
+        "headers": {
+            "Location": {
+                "schema": {
+                    "type": "string"
+                }
+            }
+        }
+    })
+}
+
+fn block_document_schema() -> Value {
+    raw_json_object_or_null(
+        "Full block document as served by neardata, including `block` and `shards`.",
+    )
+}
+
+fn headers_document_schema() -> Value {
+    raw_json_object_or_null(
+        "Block-level object returned by `/headers`, corresponding to the full response's `block` field.",
+    )
+}
+
+fn shard_document_schema() -> Value {
+    raw_json_object_or_null("Shard object for the requested shard ID.")
+}
+
+fn chunk_document_schema() -> Value {
+    raw_json_object_or_null("Chunk object for the requested shard ID.")
+}
+
+fn raw_json_object_or_null(description: &str) -> Value {
+    json!({
+        "type": "object",
+        "nullable": true,
+        "additionalProperties": true,
+        "description": description
+    })
+}
+
+fn api_key_parameter() -> Value {
+    json!({
+        "name": "apiKey",
+        "in": "query",
+        "required": false,
+        "description": "Optional FastNEAR subscription API key. Invalid values may return `401` before redirect handling.",
+        "schema": {
+            "type": "string"
+        }
+    })
+}
+
+fn block_height_parameter() -> Value {
+    json!({
+        "name": "block_height",
+        "in": "path",
+        "required": true,
+        "description": "NEAR block height to retrieve.",
+        "schema": {
+            "type": "string"
+        },
+        "example": "9820210"
+    })
+}
+
+fn shard_id_parameter(description: &str) -> Value {
+    json!({
+        "name": "shard_id",
+        "in": "path",
+        "required": true,
+        "description": description,
+        "schema": {
+            "type": "string"
+        },
+        "example": "0"
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{
+        block_document_schema, block_height_parameter, block_operation, headers_document_schema,
+        raw_json_object_or_null,
+    };
+
+    #[test]
+    fn raw_json_schemas_stay_nullable_objects() {
+        let schema = raw_json_object_or_null("Example");
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["nullable"], true);
+        assert_eq!(schema["additionalProperties"], true);
+    }
+
+    #[test]
+    fn block_schema_fragments_preserve_object_or_null_shape() {
+        assert_eq!(block_document_schema()["nullable"], true);
+        assert_eq!(headers_document_schema()["type"], "object");
+    }
+
+    #[test]
+    fn block_routes_document_redirect_auth_and_not_found_statuses() {
+        let doc = block_operation(
+            "block",
+            "NEAR Data API - Block",
+            "get_block",
+            "Fetch a finalized block by height",
+            "Example description",
+            block_document_schema(),
+            vec![block_height_parameter()],
+            json!({
+                "$ref": "#/components/schemas/BlockErrorResponse"
+            }),
+        );
+        let responses = &doc["responses"];
+
+        assert!(responses["200"].is_object());
+        assert!(responses["302"].is_object());
+        assert!(responses["401"].is_object());
+        assert!(responses["404"].is_object());
+        assert!(responses["500"].is_object());
+    }
+
+    #[test]
+    fn block_error_schema_examples_preserve_wire_enum_values() {
+        let doc = block_operation(
+            "block",
+            "NEAR Data API - Block",
+            "get_block",
+            "Fetch a finalized block by height",
+            "Example description",
+            block_document_schema(),
+            vec![block_height_parameter()],
+            json!({
+                "$ref": "#/components/schemas/BlockErrorResponse"
+            }),
+        );
+
+        assert_eq!(
+            doc["responses"]["404"]["content"]["application/json"]["example"],
+            json!({
+                "error": "The block does not exist in this archive range",
+                "type": "BLOCK_DOES_NOT_EXIST"
+            })
+        );
+    }
+}

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use fastnear_openapi_generator::{write_or_check_yaml, SchemaRegistry};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 use crate::types::{BlockErrorResponse, HealthResponse};
 
@@ -13,7 +13,12 @@ pub fn generate(check: bool) -> Result<()> {
     let mut registry = SchemaRegistry::openapi3();
     let health = registry.schema_ref::<HealthResponse>();
     let block_error = registry.schema_ref::<BlockErrorResponse>();
-    let components = registry.into_components();
+    let mut components = registry.into_components();
+    insert_generated_schemas(
+        components
+            .as_object_mut()
+            .expect("schema registry should serialize as a JSON object"),
+    );
 
     let doc = json!({
         "openapi": API_VERSION,
@@ -291,31 +296,663 @@ fn redirect_response(description: &str) -> Value {
 }
 
 fn block_document_schema() -> Value {
-    raw_json_object_or_null(
-        "Full block document as served by neardata, including `block` and `shards`.",
-    )
+    component_ref_or_null("BlockDocument")
 }
 
 fn headers_document_schema() -> Value {
-    raw_json_object_or_null(
-        "Block-level object returned by `/headers`, corresponding to the full response's `block` field.",
-    )
+    component_ref_or_null("BlockEnvelope")
 }
 
 fn shard_document_schema() -> Value {
-    raw_json_object_or_null("Shard object for the requested shard ID.")
+    component_ref_or_null("ShardDocument")
 }
 
 fn chunk_document_schema() -> Value {
-    raw_json_object_or_null("Chunk object for the requested shard ID.")
+    component_ref_or_null("ChunkDocument")
 }
 
-fn raw_json_object_or_null(description: &str) -> Value {
+fn component_ref(name: &str) -> Value {
+    json!({
+        "$ref": format!("#/components/schemas/{name}")
+    })
+}
+
+fn component_ref_or_null(name: &str) -> Value {
+    json!({
+        "nullable": true,
+        "$ref": format!("#/components/schemas/{name}")
+    })
+}
+
+fn insert_generated_schemas(components: &mut Map<String, Value>) {
+    for (name, schema) in [
+        ("BlockDocument", block_document_component()),
+        ("BlockEnvelope", block_envelope_component()),
+        ("BlockHeader", block_header_component()),
+        ("ChunkDocument", chunk_document_component()),
+        ("ChunkHeader", chunk_header_component()),
+        ("ChunkTransactionWrapper", chunk_transaction_wrapper_component()),
+        ("ActionDocument", action_document_component()),
+        ("ActionReceiptBody", action_receipt_body_component()),
+        ("ActionReceiptDocument", action_receipt_document_component()),
+        ("DataReceiptBody", data_receipt_body_component()),
+        ("DataReceiptDocument", data_receipt_document_component()),
+        ("ExecutionWithReceipt", execution_with_receipt_component()),
+        ("ExecutionOutcomeDocument", execution_outcome_document_component()),
+        ("ExecutionOutcomeStatus", execution_outcome_status_component()),
+        (
+            "ExecutionOutcomeStatusFailure",
+            execution_outcome_status_failure_component(),
+        ),
+        (
+            "ExecutionOutcomeStatusSuccessReceiptId",
+            execution_outcome_status_success_receipt_id_component(),
+        ),
+        (
+            "ExecutionOutcomeStatusSuccessValue",
+            execution_outcome_status_success_value_component(),
+        ),
+        ("ExecutionOutcomeSummary", execution_outcome_summary_component()),
+        ("ExecutionProofItem", execution_proof_item_component()),
+        ("OmittedReceiptDocument", omitted_receipt_document_component()),
+        (
+            "OutputDataReceiverDocument",
+            output_data_receiver_document_component(),
+        ),
+        ("ReceiptBody", receipt_body_component()),
+        ("ReceiptDocument", receipt_document_component()),
+        ("ShardDocument", shard_document_component()),
+        ("StateChangeItem", state_change_item_component()),
+        ("SignedTransactionDocument", signed_transaction_document_component()),
+        ("StateChangeCause", state_change_cause_component()),
+        (
+            "StateChangeCauseActionReceiptGasReward",
+            state_change_cause_action_receipt_gas_reward_component(),
+        ),
+        (
+            "StateChangeCauseReceiptProcessing",
+            state_change_cause_receipt_processing_component(),
+        ),
+        (
+            "StateChangeCauseTransactionProcessing",
+            state_change_cause_transaction_processing_component(),
+        ),
+        ("StateChangeValue", state_change_value_component()),
+        (
+            "StateChangeValueAccessKeyUpdate",
+            state_change_value_access_key_update_component(),
+        ),
+        (
+            "StateChangeValueAccountUpdate",
+            state_change_value_account_update_component(),
+        ),
+        (
+            "StateChangeValueDataDeletion",
+            state_change_value_data_deletion_component(),
+        ),
+        (
+            "StateChangeValueDataUpdate",
+            state_change_value_data_update_component(),
+        ),
+    ] {
+        components.insert(name.to_string(), schema);
+    }
+}
+
+fn block_document_component() -> Value {
     json!({
         "type": "object",
-        "nullable": true,
+        "additionalProperties": false,
+        "description": "Full block document as served by neardata, including the block envelope and per-shard payloads.",
+        "properties": {
+            "block": component_ref("BlockEnvelope"),
+            "shards": {
+                "type": "array",
+                "items": component_ref("ShardDocument")
+            }
+        },
+        "required": ["block", "shards"]
+    })
+}
+
+fn block_envelope_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Block-level payload returned by neardata.",
+        "properties": {
+            "author": {
+                "type": "string",
+                "description": "Block producer account ID."
+            },
+            "chunks": {
+                "type": "array",
+                "items": component_ref("ChunkHeader")
+            },
+            "header": component_ref("BlockHeader")
+        },
+        "required": ["author", "chunks", "header"]
+    })
+}
+
+fn block_header_component() -> Value {
+    json!({
+        "type": "object",
         "additionalProperties": true,
-        "description": description
+        "description": "Block header object as served by neardata.",
+        "properties": {
+            "chunks_included": { "type": "integer", "format": "uint64" },
+            "epoch_id": { "type": "string" },
+            "gas_price": { "type": "string" },
+            "hash": { "type": "string" },
+            "height": { "type": "integer", "format": "uint64" },
+            "next_epoch_id": { "type": "string" },
+            "prev_hash": { "type": "string" },
+            "prev_height": { "type": "integer", "format": "uint64" },
+            "timestamp": { "type": "integer" },
+            "timestamp_nanosec": { "type": "string" },
+            "total_supply": { "type": "string" }
+        }
+    })
+}
+
+fn chunk_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+        "properties": {
+            "author": {
+                "type": "string",
+                "description": "Chunk producer account ID."
+            },
+            "header": component_ref("ChunkHeader"),
+            "receipts": {
+                "type": "array",
+                "items": component_ref("ReceiptDocument")
+            },
+            "transactions": {
+                "type": "array",
+                "items": component_ref("ChunkTransactionWrapper")
+            }
+        },
+        "required": ["author", "header", "receipts", "transactions"]
+    })
+}
+
+fn chunk_header_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Chunk header object as served by neardata.",
+        "properties": {
+            "chunk_hash": { "type": "string" },
+            "gas_limit": { "type": "integer" },
+            "gas_used": { "type": "integer" },
+            "height_created": { "type": "integer", "format": "uint64" },
+            "height_included": { "type": "integer", "format": "uint64" },
+            "outcome_root": { "type": "string" },
+            "outgoing_receipts_root": { "type": "string" },
+            "prev_block_hash": { "type": "string" },
+            "shard_id": { "type": "integer", "format": "uint64" },
+            "tx_root": { "type": "string" }
+        }
+    })
+}
+
+fn chunk_transaction_wrapper_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Transaction entry returned inside a neardata chunk.",
+        "properties": {
+            "outcome": component_ref("ExecutionWithReceipt"),
+            "transaction": component_ref("SignedTransactionDocument")
+        },
+        "required": ["outcome", "transaction"]
+    })
+}
+
+fn action_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": true
+    })
+}
+
+fn action_receipt_body_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "Action": component_ref("ActionReceiptDocument")
+        },
+        "required": ["Action"]
+    })
+}
+
+fn action_receipt_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "actions": {
+                "type": "array",
+                "items": component_ref("ActionDocument")
+            },
+            "gas_price": { "type": "string" },
+            "input_data_ids": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "is_promise_yield": { "type": "boolean" },
+            "output_data_receivers": {
+                "type": "array",
+                "items": component_ref("OutputDataReceiverDocument")
+            },
+            "signer_id": { "type": "string" },
+            "signer_public_key": { "type": "string" }
+        },
+        "required": [
+            "actions",
+            "gas_price",
+            "input_data_ids",
+            "is_promise_yield",
+            "output_data_receivers",
+            "signer_id",
+            "signer_public_key"
+        ]
+    })
+}
+
+fn data_receipt_body_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "Data": component_ref("DataReceiptDocument")
+        },
+        "required": ["Data"]
+    })
+}
+
+fn data_receipt_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "data": { "type": "string" },
+            "data_id": { "type": "string" },
+            "is_promise_resume": { "type": "boolean" }
+        },
+        "required": ["data", "data_id", "is_promise_resume"]
+    })
+}
+
+fn execution_with_receipt_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Execution result paired with an optional receipt object.",
+        "properties": {
+            "execution_outcome": component_ref("ExecutionOutcomeDocument"),
+            "receipt": {
+                "type": "object",
+                "nullable": true,
+                "description": "Receipt payload when neardata includes it for this entry.",
+                "oneOf": [
+                    component_ref("ReceiptDocument"),
+                    component_ref("OmittedReceiptDocument")
+                ]
+            },
+            "tx_hash": { "type": "string" }
+        },
+        "required": ["execution_outcome", "receipt"]
+    })
+}
+
+fn execution_outcome_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "block_hash": { "type": "string" },
+            "id": { "type": "string" },
+            "outcome": component_ref("ExecutionOutcomeSummary"),
+            "proof": {
+                "type": "array",
+                "items": component_ref("ExecutionProofItem")
+            }
+        },
+        "required": ["block_hash", "id", "outcome", "proof"]
+    })
+}
+
+fn execution_outcome_status_component() -> Value {
+    json!({
+        "oneOf": [
+            component_ref("ExecutionOutcomeStatusSuccessReceiptId"),
+            component_ref("ExecutionOutcomeStatusSuccessValue"),
+            component_ref("ExecutionOutcomeStatusFailure")
+        ]
+    })
+}
+
+fn execution_outcome_status_failure_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "Failure": {
+                "type": "object",
+                "additionalProperties": true
+            }
+        },
+        "required": ["Failure"]
+    })
+}
+
+fn execution_outcome_status_success_receipt_id_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "SuccessReceiptId": { "type": "string" }
+        },
+        "required": ["SuccessReceiptId"]
+    })
+}
+
+fn execution_outcome_status_success_value_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "SuccessValue": { "type": "string" }
+        },
+        "required": ["SuccessValue"]
+    })
+}
+
+fn execution_outcome_summary_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "executor_id": { "type": "string" },
+            "gas_burnt": { "type": "integer", "format": "uint64" },
+            "logs": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "metadata": {
+                "type": "object",
+                "additionalProperties": true
+            },
+            "receipt_ids": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "status": component_ref("ExecutionOutcomeStatus"),
+            "tokens_burnt": { "type": "string" }
+        },
+        "required": [
+            "executor_id",
+            "gas_burnt",
+            "logs",
+            "metadata",
+            "receipt_ids",
+            "status",
+            "tokens_burnt"
+        ]
+    })
+}
+
+fn execution_proof_item_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": true
+    })
+}
+
+fn omitted_receipt_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false
+    })
+}
+
+fn output_data_receiver_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "data_id": { "type": "string" },
+            "receiver_id": { "type": "string" }
+        },
+        "required": ["data_id", "receiver_id"]
+    })
+}
+
+fn receipt_body_component() -> Value {
+    json!({
+        "oneOf": [
+            component_ref("ActionReceiptBody"),
+            component_ref("DataReceiptBody")
+        ]
+    })
+}
+
+fn receipt_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Receipt object as served by neardata inside a chunk payload.",
+        "properties": {
+            "predecessor_id": { "type": "string" },
+            "priority": { "type": "integer", "format": "uint64" },
+            "receipt": component_ref("ReceiptBody"),
+            "receipt_id": { "type": "string" },
+            "receiver_id": { "type": "string" }
+        },
+        "required": [
+            "predecessor_id",
+            "priority",
+            "receipt",
+            "receipt_id",
+            "receiver_id"
+        ]
+    })
+}
+
+fn shard_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Per-shard payload returned by neardata for a block.",
+        "properties": {
+            "chunk": component_ref("ChunkDocument"),
+            "receipt_execution_outcomes": {
+                "type": "array",
+                "items": component_ref("ExecutionWithReceipt")
+            },
+            "shard_id": { "type": "integer", "format": "uint64" },
+            "state_changes": {
+                "type": "array",
+                "items": component_ref("StateChangeItem")
+            }
+        },
+        "required": [
+            "chunk",
+            "receipt_execution_outcomes",
+            "shard_id",
+            "state_changes"
+        ]
+    })
+}
+
+fn state_change_item_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "description": "State change entry returned by neardata for a shard.",
+        "properties": {
+            "cause": component_ref("StateChangeCause"),
+            "change": component_ref("StateChangeValue"),
+            "type": { "type": "string" }
+        },
+        "required": ["cause", "change", "type"]
+    })
+}
+
+fn signed_transaction_document_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "actions": {
+                "type": "array",
+                "items": component_ref("ActionDocument")
+            },
+            "hash": { "type": "string" },
+            "nonce": { "type": "integer", "format": "uint64" },
+            "priority_fee": { "type": "integer", "format": "uint64" },
+            "public_key": { "type": "string" },
+            "receiver_id": { "type": "string" },
+            "signature": { "type": "string" },
+            "signer_id": { "type": "string" }
+        },
+        "required": [
+            "actions",
+            "hash",
+            "nonce",
+            "priority_fee",
+            "public_key",
+            "receiver_id",
+            "signature",
+            "signer_id"
+        ]
+    })
+}
+
+fn state_change_cause_component() -> Value {
+    json!({
+        "oneOf": [
+            component_ref("StateChangeCauseTransactionProcessing"),
+            component_ref("StateChangeCauseReceiptProcessing"),
+            component_ref("StateChangeCauseActionReceiptGasReward")
+        ]
+    })
+}
+
+fn state_change_cause_action_receipt_gas_reward_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "receipt_hash": { "type": "string" },
+            "type": { "type": "string" }
+        },
+        "required": ["receipt_hash", "type"]
+    })
+}
+
+fn state_change_cause_receipt_processing_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "receipt_hash": { "type": "string" },
+            "type": { "type": "string" }
+        },
+        "required": ["receipt_hash", "type"]
+    })
+}
+
+fn state_change_cause_transaction_processing_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "tx_hash": { "type": "string" },
+            "type": { "type": "string" }
+        },
+        "required": ["tx_hash", "type"]
+    })
+}
+
+fn state_change_value_component() -> Value {
+    json!({
+        "oneOf": [
+            component_ref("StateChangeValueAccountUpdate"),
+            component_ref("StateChangeValueAccessKeyUpdate"),
+            component_ref("StateChangeValueDataUpdate"),
+            component_ref("StateChangeValueDataDeletion")
+        ]
+    })
+}
+
+fn state_change_value_access_key_update_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "access_key": {
+                "type": "object",
+                "additionalProperties": true
+            },
+            "account_id": { "type": "string" },
+            "public_key": { "type": "string" }
+        },
+        "required": ["access_key", "account_id", "public_key"]
+    })
+}
+
+fn state_change_value_account_update_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "account_id": { "type": "string" },
+            "amount": { "type": "string" },
+            "code_hash": { "type": "string" },
+            "locked": { "type": "string" },
+            "storage_paid_at": { "type": "integer", "format": "uint64" },
+            "storage_usage": { "type": "integer", "format": "uint64" }
+        },
+        "required": [
+            "account_id",
+            "amount",
+            "code_hash",
+            "locked",
+            "storage_paid_at",
+            "storage_usage"
+        ]
+    })
+}
+
+fn state_change_value_data_deletion_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "account_id": { "type": "string" },
+            "key_base64": { "type": "string" }
+        },
+        "required": ["account_id", "key_base64"]
+    })
+}
+
+fn state_change_value_data_update_component() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "account_id": { "type": "string" },
+            "key_base64": { "type": "string" },
+            "value_base64": { "type": "string" }
+        },
+        "required": ["account_id", "key_base64", "value_base64"]
     })
 }
 
@@ -363,22 +1000,23 @@ mod tests {
 
     use super::{
         block_document_schema, block_height_parameter, block_operation, headers_document_schema,
-        raw_json_object_or_null,
     };
 
     #[test]
-    fn raw_json_schemas_stay_nullable_objects() {
-        let schema = raw_json_object_or_null("Example");
+    fn component_refs_stay_nullable() {
+        let schema = block_document_schema();
 
-        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["$ref"], "#/components/schemas/BlockDocument");
         assert_eq!(schema["nullable"], true);
-        assert_eq!(schema["additionalProperties"], true);
     }
 
     #[test]
-    fn block_schema_fragments_preserve_object_or_null_shape() {
+    fn block_schema_fragments_preserve_component_refs() {
         assert_eq!(block_document_schema()["nullable"], true);
-        assert_eq!(headers_document_schema()["type"], "object");
+        assert_eq!(
+            headers_document_schema()["$ref"],
+            "#/components/schemas/BlockEnvelope"
+        );
     }
 
     #[test]

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -45,7 +45,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block",
                     "get_block",
                     "Fetch a finalized block by height",
-                    "Returns the finalized block document for the requested height, or `null` when the block does not exist within the requested archive segment. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    "Fetch the finalized block document for a given height, including all chunks and shard data.",
                     block_document_schema(),
                     vec![block_height_parameter()],
                     block_error.clone()
@@ -57,7 +57,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block Headers",
                     "get_block_headers",
                     "Fetch the block-level object for a finalized block",
-                    "Returns the `block` object extracted from the full block response, not just the nested `header` sub-object. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    "Fetch the top-level block object for a finalized block, including the block header and chunk summaries.",
                     headers_document_schema(),
                     vec![block_height_parameter()],
                     block_error.clone()
@@ -69,7 +69,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block Chunk",
                     "get_chunk",
                     "Fetch one chunk from a finalized block",
-                    "Returns the chunk object for the requested shard ID, or `null` when that chunk is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    "Fetch a single chunk for a given finalized block and shard ID.",
                     chunk_document_schema(),
                     vec![block_height_parameter(), shard_id_parameter("Shard ID whose chunk should be returned.")],
                     block_error.clone()
@@ -81,7 +81,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block Shard",
                     "get_shard",
                     "Fetch one shard from a finalized block",
-                    "Returns the shard object for the requested shard ID, or `null` when that shard is absent. Depending on deployment topology, the request may redirect to another host that owns the canonical archive range.",
+                    "Fetch a single shard document for a given finalized block and shard ID.",
                     shard_document_schema(),
                     vec![block_height_parameter(), shard_id_parameter("Shard ID to return.")],
                     block_error.clone()
@@ -93,7 +93,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Optimistic Block",
                     "get_block_optimistic",
                     "Fetch an optimistic block by height",
-                    "Returns an optimistic block document when the deployment can serve it directly. Older or archive-only heights may redirect to a canonical finalized or archive URL instead.",
+                    "Fetch an optimistic block document when the endpoint can serve it directly, or follow the documented redirect behavior when the deployment hands off to finalized or archive infrastructure.",
                     block_document_schema(),
                     vec![block_height_parameter()],
                     block_error.clone()
@@ -105,7 +105,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Last Final Block",
                     "get_last_block_final",
                     "Redirect to the latest finalized block",
-                    "Returns a redirect to the canonical latest finalized block URL for the current deployment. Clients that automatically follow redirects will receive the full block document instead."
+                    "This endpoint redirects to the latest finalized block URL for the active deployment."
                 )
             },
             "/v0/last_block/optimistic": {
@@ -114,7 +114,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Last Optimistic Block",
                     "get_last_block_optimistic",
                     "Redirect to the latest optimistic block",
-                    "Returns a redirect to the canonical latest optimistic block URL for the current deployment. Clients that automatically follow redirects will receive the resulting block document instead."
+                    "This endpoint redirects to the latest optimistic block URL for the active deployment."
                 )
             }
         },
@@ -131,7 +131,7 @@ fn health_operation(health_schema: Value) -> Value {
     json!({
         "operationId": "get_health",
         "summary": "Get service health",
-        "description": "Returns `ok` when the current deployment is healthy and `unhealthy` when the latest indexed block is too stale. Invalid API keys can be rejected upstream before the request reaches the app.",
+        "description": "Check whether the neardata service is healthy for the current deployment.",
         "tags": ["system"],
         "x-fastnear-slug": "health",
         "x-fastnear-title": "NEAR Data API - Health",
@@ -152,7 +152,7 @@ fn first_block_operation() -> Value {
     json!({
         "operationId": "get_first_block",
         "summary": "Redirect to the first block after genesis",
-        "description": "Returns a redirect to the canonical first block URL for the selected deployment. Clients that automatically follow redirects will receive the full block document instead.",
+        "description": "This endpoint redirects to the canonical first block URL for the selected network.",
         "tags": ["blocks"],
         "x-fastnear-slug": "first_block",
         "x-fastnear-title": "NEAR Data API - First Block",

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -45,7 +45,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block",
                     "get_block",
                     "Fetch a finalized block by height",
-                    "Fetch the finalized block document for a given height, including all chunks and shard data.",
+                    "Fetch a finalized block's full document at a chosen height — header plus every chunk and shard payload.",
                     block_document_schema(),
                     vec![block_height_parameter()],
                     block_error.clone()
@@ -57,7 +57,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block Headers",
                     "get_block_headers",
                     "Fetch the block-level object for a finalized block",
-                    "Fetch the top-level block object for a finalized block, including the block header and chunk summaries.",
+                    "Fetch only a finalized block's header and chunk summaries — no per-shard payload.",
                     headers_document_schema(),
                     vec![block_height_parameter()],
                     block_error.clone()
@@ -69,7 +69,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block Chunk",
                     "get_chunk",
                     "Fetch one chunk from a finalized block",
-                    "Fetch a single chunk for a given finalized block and shard ID.",
+                    "Fetch one chunk — a single shard's transactions and incoming receipts — at a chosen block height.",
                     chunk_document_schema(),
                     vec![block_height_parameter(), shard_id_parameter("Shard ID whose chunk should be returned.")],
                     block_error.clone()
@@ -81,7 +81,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Block Shard",
                     "get_shard",
                     "Fetch one shard from a finalized block",
-                    "Fetch a single shard document for a given finalized block and shard ID.",
+                    "Fetch one shard's full payload at a chosen block — chunk plus state changes and produced receipts.",
                     shard_document_schema(),
                     vec![block_height_parameter(), shard_id_parameter("Shard ID to return.")],
                     block_error.clone()
@@ -93,7 +93,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Optimistic Block",
                     "get_block_optimistic",
                     "Fetch an optimistic block by height",
-                    "Fetch an optimistic block document when the endpoint can serve it directly, or follow the documented redirect behavior when the deployment hands off to finalized or archive infrastructure.",
+                    "Fetch an optimistic (not-yet-final) block at a chosen height — may redirect once the optimistic window has finalized.",
                     block_document_schema(),
                     vec![block_height_parameter()],
                     block_error.clone()
@@ -105,7 +105,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Last Final Block",
                     "get_last_block_final",
                     "Redirect to the latest finalized block",
-                    "This endpoint redirects to the latest finalized block URL for the active deployment."
+                    "Redirect to the most recent finalized block — the chain-tip cursor once consensus has settled."
                 )
             },
             "/v0/last_block/optimistic": {
@@ -114,7 +114,7 @@ pub fn generate(check: bool) -> Result<()> {
                     "NEAR Data API - Last Optimistic Block",
                     "get_last_block_optimistic",
                     "Redirect to the latest optimistic block",
-                    "This endpoint redirects to the latest optimistic block URL for the active deployment."
+                    "Redirect to the most recent optimistic block — the freshest-possible tip, ahead of final settlement."
                 )
             }
         },
@@ -131,7 +131,7 @@ fn health_operation(health_schema: Value) -> Value {
     json!({
         "operationId": "get_health",
         "summary": "Get service health",
-        "description": "Check whether the neardata service is healthy for the current deployment.",
+        "description": "Ping the neardata service for liveness — returns `{status: ok}` when healthy, errors otherwise.",
         "tags": ["system"],
         "x-fastnear-slug": "health",
         "x-fastnear-title": "NEAR Data API - Health",
@@ -152,7 +152,7 @@ fn first_block_operation() -> Value {
     json!({
         "operationId": "get_first_block",
         "summary": "Redirect to the first block after genesis",
-        "description": "This endpoint redirects to the canonical first block URL for the selected network.",
+        "description": "Redirect to the chain's first post-genesis block — a starting cursor for indexers backfilling from the beginning.",
         "tags": ["blocks"],
         "x-fastnear-slug": "first_block",
         "x-fastnear-title": "NEAR Data API - First Block",

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use serde::Serialize;
+
 pub type BlockHeight = u64;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -53,5 +55,74 @@ impl TryFrom<String> for Finality {
             "optimistic" => Ok(Finality::Optimistic),
             _ => Err(format!("Invalid finality: {}", value)),
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct HealthResponse {
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "openapi", schemars(deny_unknown_fields))]
+pub struct BlockErrorResponse {
+    pub error: String,
+    #[serde(rename = "type")]
+    pub error_type: BlockErrorType,
+}
+
+impl BlockErrorResponse {
+    pub fn new(error: impl Into<String>, error_type: BlockErrorType) -> Self {
+        Self {
+            error: error.into(),
+            error_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(feature = "openapi", derive(schemars::JsonSchema))]
+pub enum BlockErrorType {
+    BlockHeightTooHigh,
+    BlockHeightTooLow,
+    BlockDoesNotExist,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{BlockErrorResponse, BlockErrorType, HealthResponse};
+
+    #[test]
+    fn health_response_serializes_current_wire_shape() {
+        let response = HealthResponse {
+            status: "ok".to_string(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({ "status": "ok" })
+        );
+    }
+
+    #[test]
+    fn block_error_response_uses_current_field_names_and_values() {
+        let response = BlockErrorResponse::new(
+            "The block is too far in the future",
+            BlockErrorType::BlockDoesNotExist,
+        );
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap(),
+            json!({
+                "error": "The block is too far in the future",
+                "type": "BLOCK_DOES_NOT_EXIST"
+            })
+        );
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -180,9 +180,10 @@
 <h2>Rate Limits &amp; Authentication</h2>
 <p>The public access rate limit is <strong>180 requests per minute per IP</strong>.</p>
 <p>To increase your rate limits, get a subscription at <a href='https://fastnear.com/'>https://fastnear.com/</a>.</p>
-<p>To authenticate your requests with a FastNear Subscription API key, attach the following query string to the URL:
+<p>To authenticate your requests with a FastNEAR Subscription API key, attach the following query string to the URL:
   <code>?apiKey={API_KEY}</code></p>
 <p>Example: <a href="/v0/block/98765432?apiKey=YOUR_API_KEY">/v0/block/98765432?apiKey=YOUR_API_KEY</a></p>
+<p>Invalid API keys may return <code>401 Unauthorized</code> before the request reaches the neardata application.</p>
 <p><strong>Note:</strong> Authentication using the <code>Authorization: Bearer</code> header requires you to manually
   handle redirects,
   since the redirect URL will not pass the header through and the redirected request will not be authenticated.</p>
@@ -196,6 +197,8 @@
   <li> If the block is not produced yet, but close to the current finalized block,
     the server will wait for the block to be produced and return it.
   </li>
+  <li> Depending on deployment topology, this route may redirect to the host that owns the canonical archive range.
+  </li>
   <li> The difference from NEAR Lake data is each block is served as a single
     JSON object, instead of the block and shards. Another benefit, is we include
     the <code>tx_hash</code> for every receipt in the <code>receipt_execution_outcomes</code>.
@@ -207,8 +210,8 @@
 
 <h3>GET /v0/block/:block_height/headers</h3>
 
-<p>Logic is similar to the <code>GET /v0/block/</code> but returns only the <code>.block</code> key from the big
-  response. This will include the block header with chunk headers</p>
+<p>Logic is similar to the <code>GET /v0/block/</code> route but returns the top-level <code>block</code> object from
+  the full response, including the block header and chunk summaries.</p>
 
 <p>Example: <a href='/v0/block/100000000/headers'>/v0/block/100000000/headers</a></p>
 
@@ -225,7 +228,8 @@
 <p>Example: <a href='/v0/block/100000000/shard/0'>/v0/block/100000000/shard/0</a></p>
 
 <h3>GET /v0/block_opt</h3>
-<p>Returns the optimistic block by block height or redirects to the finalized block.</p>
+<p>Returns the optimistic block by block height or redirects to the canonical finalized or archive URL when the
+  deployment cannot serve it directly.</p>
 
 <p>Example: <a href='/v0/block_opt/122000000'>/v0/block_opt/122000000</a></p>
 

--- a/static/skill.md
+++ b/static/skill.md
@@ -13,7 +13,7 @@ To increase your rate limits, get a subscription at [https://fastnear.com/](http
 
 ## Authentication
 
-To authenticate your requests with a FastNear Subscription API key, attach the following query string to the URL:
+To authenticate your requests with a FastNEAR Subscription API key, attach the following query string to the URL:
 
 ```
 ?apiKey={API_KEY}
@@ -23,6 +23,8 @@ For example:
 ```
 https://mainnet.neardata.xyz/v0/block/98765432?apiKey=YOUR_API_KEY
 ```
+
+Invalid API keys may return `401 Unauthorized` before redirect handling.
 
 > **Note:** Authentication using the `Authorization: Bearer` header requires you to manually handle redirects, since the redirect URL will not pass the header through and the redirected request will not be authenticated.
 
@@ -37,9 +39,9 @@ FASTNEAR provides servers for both mainnet and testnet:
 
 - `/v0/first_block` - Redirects to the first block after genesis.
 - `/v0/block/:block_height` - Get a finalized block by the block height in a JSON format.
-- `/v0/block/:block_height/headers` - Get block headers only.
+- `/v0/block/:block_height/headers` - Get the block-level object returned under `block`.
 - `/v0/block/:block_height/chunk/:shard_id` - Get a single chunk of a block.
 - `/v0/block/:block_height/shard/:shard_id` - Get a single shard of a block.
-- `/v0/block_opt/:block_height` - Get an optimistic block by the block height in a JSON format.
+- `/v0/block_opt/:block_height` - Get an optimistic block by height, or follow its documented redirect behavior.
 - `/v0/last_block/final` - Redirects to the latest finalized block.
 - `/v0/last_block/optimistic` - Redirects to the latest optimistic block.


### PR DESCRIPTION
## Summary

This moves `neardata-server` to owning its aggregate OpenAPI document in-repo.

The checked-in `openapi/openapi.yaml` file is now generated from typed Rust DTOs plus a Rust-owned operation registry, instead of being maintained outside the service repo.

## What changed

- add an `openapi` feature with a `generate-openapi` binary
- add `src/openapi.rs` to build the aggregate OpenAPI document
- check in `openapi/openapi.yaml`
- move shared app state, scopes, and docs-serving handlers into `lib.rs` so both the server binary and the OpenAPI generator can reuse them
- update README and static docs text to describe the current docs pipeline

This covers `/health` plus the block-family redirect and document endpoints under `/v0`.

## Why the `main.rs` -> `lib.rs` split

This is not intended as an architectural rewrite.

Rust binaries cannot be imported by other binaries, so the new `generate-openapi` binary needed a small shared library surface for:
- app state types
- route scopes and docs handlers
- request and response DTOs

The server startup flow remains in `main.rs`; the shared reusable pieces moved to `lib.rs`.

## What did not change

- the public HTTP routes and handlers remain the same
- the static docs and skill content changes are wording and pipeline alignment, not a functional API change
- server startup, env loading, logging, and binding remain in `main.rs`
- portal-owned per-operation splitting and docs enhancements still live outside this repo

## Validation

```bash
cargo check
cargo run --features openapi --bin generate-openapi -- --check
```
